### PR TITLE
Add state load/save tests

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,16 @@
+from encompass_to_samsara.state import load_state, save_state, DEFAULT_STATE
+
+def test_load_state_missing_file_returns_default(tmp_path):
+    path = tmp_path / "state.json"
+    assert load_state(str(path)) == DEFAULT_STATE
+
+def test_load_state_invalid_json_returns_default(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("{ not valid json", encoding="utf-8")
+    assert load_state(str(path)) == DEFAULT_STATE
+
+def test_save_and_load_state_roundtrip(tmp_path):
+    path = tmp_path / "nested" / "state.json"
+    state = {"fingerprints": {"1": "fp"}, "candidate_deletes": {"2": "del"}}
+    save_state(str(path), state)
+    assert load_state(str(path)) == state


### PR DESCRIPTION
## Summary
- add unit tests for `load_state` default behavior when state file is missing or invalid
- verify `save_state` and `load_state` perform a round-trip

## Testing
- `pytest tests/test_state.py -q`
- `pytest -q` *(fails: Connection refused by Responses - the call doesn't match any registered mock; probable_match assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f25fd62c83288d3630085526fb5c