### PR TITLE
Add retry test for SamsaraClient

### DIFF
--- a/tests/test_samsara_client.py
+++ b/tests/test_samsara_client.py
@@ -1,0 +1,37 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from encompass_to_samsara.samsara_client import SamsaraClient
+
+
+def make_response(status_code: int, json_body=None, headers=None):
+    resp = requests.Response()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    if json_body is not None:
+        resp._content = json.dumps(json_body).encode("utf-8")
+    else:
+        resp._content = b""
+    return resp
+
+
+def test_request_retries_on_429(monkeypatch, client):
+    r1 = make_response(429)
+    r2 = make_response(200, {"ok": True})
+
+    mock_req = Mock(side_effect=[r1, r2])
+    monkeypatch.setattr(requests.Session, "request", mock_req)
+
+    sleep_mock = Mock()
+    monkeypatch.setattr("time.sleep", sleep_mock)
+    monkeypatch.setattr("random.random", lambda: 0.0)
+
+    resp = client.request("GET", "/foo")
+
+    assert resp is r2
+    assert mock_req.call_count == 2
+    sleep_mock.assert_called_once()
+    assert sleep_mock.call_args[0][0] == pytest.approx(client.retry.base_delay)


### PR DESCRIPTION
## Summary
- add test to verify SamsaraClient retries and sleeps on transient 429 before succeeding

## Testing
- `pytest tests/test_samsara_client.py -q`
- `pytest tests/test_matcher.py -q` *(fails: assertion)*
- `pytest tests/test_daily.py -q` *(fails: ConnectionError)*
- `pytest tests/test_tags.py -q`
- `pytest tests/test_transform.py -q`
- `pytest tests/test_sync_full.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f264069c832896fd014d5fae82b1