### PR TITLE
Support EncompassId alias for address IDs

### DIFF
--- a/src/encompass_to_samsara/matcher.py
+++ b/src/encompass_to_samsara/matcher.py
@@ -21,7 +21,7 @@ def index_addresses_by_external_id(addresses: List[dict]) -> Dict[str, dict]:
     idx: Dict[str, dict] = {}
     for a in addresses:
         ext = a.get("externalIds") or {}
-        eid = ext.get("encompass_id") or ext.get("ENCOMPASS_ID")
+        eid = ext.get("encompass_id") or ext.get("ENCOMPASS_ID") or ext.get("EncompassId")
         if eid:
             idx[str(eid)] = a
     return idx

--- a/src/encompass_to_samsara/safety.py
+++ b/src/encompass_to_samsara/safety.py
@@ -53,7 +53,7 @@ def is_warehouse(address: dict, warehouse_ids: set[str], warehouse_names_lc: set
 
 def is_managed(address: dict, managed_tag_id: str | None) -> bool:
     ext = address.get("externalIds") or {}
-    if ext.get("encompass_id") or ext.get("ENCOMPASS_ID"):
+    if ext.get("encompass_id") or ext.get("ENCOMPASS_ID") or ext.get("EncompassId"):
         return True
     # Look for ManagedBy tag
     if managed_tag_id:

--- a/src/encompass_to_samsara/sync_full.py
+++ b/src/encompass_to_samsara/sync_full.py
@@ -14,6 +14,11 @@ from .reporting import Action, ensure_out_dir, write_jsonl, write_csv, summarize
 
 LOG = logging.getLogger(__name__)
 
+
+def _ext_encompass_id(ext: Dict[str, Any]) -> str | None:
+    """Return the Encompass external ID if present."""
+    return ext.get("encompass_id") or ext.get("ENCOMPASS_ID") or ext.get("EncompassId")
+
 def run_full(
     client: SamsaraClient,
     *, encompass_csv: str, warehouses_path: str, out_dir: str,
@@ -102,7 +107,7 @@ def run_full(
                 needs_scope = True
             if ext.get("ENCOMPASS_MANAGED") != "1":
                 needs_scope = True
-            if ext.get("encompass_id") != r.encompass_id:
+            if _ext_encompass_id(ext) != r.encompass_id:
                 needs_scope = True
             if needs_scope and "externalIds" not in diff:
                 # inject ext and tags
@@ -157,7 +162,7 @@ def run_full(
         if not is_managed(addr, managed_tag_id):
             continue
         ext = addr.get("externalIds") or {}
-        eid = str(ext.get("encompass_id") or ext.get("ENCOMPASS_ID") or "")
+        eid = str(_ext_encompass_id(ext) or "")
         if eid and eid in src_eids:
             continue
         # Orphan

--- a/tests/test_daily.py
+++ b/tests/test_daily.py
@@ -6,6 +6,7 @@ import responses
 
 from encompass_to_samsara.sync_daily import run_daily
 from encompass_to_samsara.samsara_client import SamsaraClient
+from encompass_to_samsara.transform import compute_fingerprint
 
 API = "https://api.samsara.com"
 
@@ -34,8 +35,9 @@ def test_daily_upsert_skip_when_unchanged(tmp_path, token_env, base_responses):
 
     # Existing matching address with same fingerprint
     # We'll compute via running once with create, then second run will skip
+    fp = compute_fingerprint("Foo", "Active", "123 A St")
     samsara_addresses = [
-        {"id":"300","name":"Foo","formattedAddress":"123 A St","externalIds":{"encompass_id":"C1","ENCOMPASS_STATUS":"Active","ENCOMPASS_MANAGED":"1","ENCOMPASS_FINGERPRINT":"dummy"}},
+        {"id":"300","name":"Foo","formattedAddress":"123 A St","externalIds":{"encompass_id":"C1","ENCOMPASS_STATUS":"Active","ENCOMPASS_MANAGED":"1","ENCOMPASS_FINGERPRINT":fp}},
     ]
 
     with base_responses as rsps:
@@ -45,7 +47,7 @@ def test_daily_upsert_skip_when_unchanged(tmp_path, token_env, base_responses):
         # Seed state
         os.makedirs(out_dir, exist_ok=True)
         with open(out_dir/"state.json","w",encoding="utf-8") as f:
-            json.dump({"fingerprints":{"300":"dummy"},"candidate_deletes":{}}, f)
+            json.dump({"fingerprints":{"300":fp},"candidate_deletes":{}}, f)
 
         run_daily(
             client,

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -77,10 +77,12 @@ def test_index_addresses_by_external_id():
     addrs = [
         {"id": "a", "externalIds": {"encompass_id": "123"}},
         {"id": "b", "externalIds": {"ENCOMPASS_ID": "456"}},
-        {"id": "c", "externalIds": {"other": "789"}},
+        {"id": "c", "externalIds": {"other": "999"}},
+        {"id": "d", "externalIds": {"EncompassId": "789"}},
     ]
     idx = index_addresses_by_external_id(addrs)
     assert idx["123"]["id"] == "a"
     assert idx["456"]["id"] == "b"
-    assert "789" not in idx
-    assert len(idx) == 2
+    assert idx["789"]["id"] == "d"
+    assert "999" not in idx
+    assert len(idx) == 3

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -42,6 +42,7 @@ def address_samples():
         "warehouse_name": {"id": "999", "name": "Main"},
         "not_warehouse": {"id": "999", "name": "Unknown"},
         "managed_external": {"externalIds": {"encompass_id": "abc"}},
+        "managed_external_alias": {"externalIds": {"EncompassId": "def"}},
         "managed_tag": {"tags": [{"id": "M1"}]},
         "unmanaged": {"tags": [{"id": "X"}]},
     }
@@ -69,6 +70,7 @@ def test_is_warehouse(address_samples, warehouse_csv):
 def test_is_managed(address_samples):
     managed_tag_id = "M1"
     assert is_managed(address_samples["managed_external"], managed_tag_id)
+    assert is_managed(address_samples["managed_external_alias"], managed_tag_id)
     assert is_managed(address_samples["managed_tag"], managed_tag_id)
     assert not is_managed(address_samples["unmanaged"], managed_tag_id)
 

--- a/tests/test_sync_full.py
+++ b/tests/test_sync_full.py
@@ -36,7 +36,7 @@ def test_full_upsert_and_quarantine(tmp_path, token_env, base_responses):
 
     # Existing Samsara addresses: one managed orphan and one unmanaged candidate
     samsara_addresses = [
-        {"id":"100","name":"Orphan1","formattedAddress":"XYZ","externalIds":{"encompass_id":"OLD"},"tagIds":["1"]},  # managed orphan
+        {"id":"100","name":"Orphan1","formattedAddress":"XYZ","externalIds":{"EncompassId":"OLD"},"tagIds":["1"]},  # managed orphan
     ]
 
     with base_responses as rsps:


### PR DESCRIPTION
## Summary
- recognize `externalIds["EncompassId"]` alongside existing Encompass ID keys
- treat `EncompassId` as evidence of managed addresses and handle it during full sync orphan detection
- expand unit tests for matcher, safety, sync_full and adjust daily test fingerprint seeding

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68accc9cb4f883289d8f2ba9ef636a54