### PR TITLE
Move export scripts into package

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Create a `.env` or export environment variables:
 
 ```bash
 export SAMSARA_BEARER_TOKEN=your_token
-python scripts/export_addresses.py
+python -m encompass_to_samsara.scripts.export_addresses
 ```
 
 The script writes all existing Samsara addresses to `addresses.json`.

--- a/src/encompass_to_samsara/scripts/export_addresses.py
+++ b/src/encompass_to_samsara/scripts/export_addresses.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from encompass_to_samsara.samsara_client import SamsaraClient
+from ..samsara_client import SamsaraClient
 
 
 def main() -> None:

--- a/src/encompass_to_samsara/scripts/export_tags.py
+++ b/src/encompass_to_samsara/scripts/export_tags.py
@@ -4,12 +4,8 @@
 from __future__ import annotations
 
 import json
-import pathlib
-import sys
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
-
-from encompass_to_samsara.samsara_client import SamsaraClient
+from ..samsara_client import SamsaraClient
 
 
 def main() -> None:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,20 +1,10 @@
 import json
-import importlib.util
-from pathlib import Path
+
 from encompass_to_samsara.samsara_client import SamsaraClient
-
-SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
-
-def load_script(name: str):
-    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(module)
-    return module
+from encompass_to_samsara.scripts import export_addresses, export_tags
 
 
 def test_export_tags(monkeypatch, tmp_path):
-    export_tags = load_script("export_tags")
     sample_tags = [
         {"id": "1", "name": "Alpha"},
         {"id": "2", "name": "Bravo"},
@@ -34,7 +24,6 @@ def test_export_tags(monkeypatch, tmp_path):
 
 
 def test_export_addresses(monkeypatch, tmp_path):
-    export_addresses = load_script("export_addresses")
     sample_addresses = [
         {
             "id": "100",


### PR DESCRIPTION
## Summary
- relocate `export_addresses.py` and `export_tags.py` into `encompass_to_samsara/scripts`
- update scripts to use package-relative imports
- fix tests and README references to new module paths

## Testing
- `ruff format src/encompass_to_samsara/scripts/export_addresses.py src/encompass_to_samsara/scripts/export_tags.py tests/test_exports.py src/encompass_to_samsara/scripts/__init__.py`
- `make lint` *(fails: E501 line too long and other lint errors)*
- `PYTHONPATH=src make test`

------
https://chatgpt.com/codex/tasks/task_e_68acde35a5b08328bbe0fdbb3a5b18cc