### PR TITLE
Parse radius as int and cast for geofence

### DIFF
--- a/src/encompass_to_samsara/cli.py
+++ b/src/encompass_to_samsara/cli.py
@@ -36,6 +36,7 @@ def cli() -> None:
     "--radius-m",
     default=lambda: int(os.getenv("E2S_DEFAULT_RADIUS_METERS", "50")),
     show_default=True,
+    type=int,
 )
 @click.option("--retention-days", default=30, show_default=True)
 @click.option("--confirm-delete", is_flag=True, help="Allow hard deletes after retention window.")
@@ -70,6 +71,7 @@ def full_cmd(
     "--radius-m",
     default=lambda: int(os.getenv("E2S_DEFAULT_RADIUS_METERS", "50")),
     show_default=True,
+    type=int,
 )
 @click.option("--retention-days", default=30, show_default=True)
 @click.option("--confirm-delete", is_flag=True, help="Allow hard deletes after retention window.")

--- a/src/encompass_to_samsara/transform.py
+++ b/src/encompass_to_samsara/transform.py
@@ -110,6 +110,7 @@ def to_address_payload(
     # Compose formatted address
     formatted_addr = row.address or ""
     fp = compute_fingerprint(row.name, row.status, formatted_addr)
+    radius_m = int(radius_m)
 
     tag_ids: list[str] = []
     # scope tag


### PR DESCRIPTION
## Summary
- ensure `--radius-m` CLI option parses integers for full and daily sync commands
- coerce `radius_m` to `int` before creating geofence payloads

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae3b0de41c832899fc426fed64a0ac