### PR TITLE
Ensure retention-days options parse integers

### DIFF
--- a/src/encompass_to_samsara/cli.py
+++ b/src/encompass_to_samsara/cli.py
@@ -37,7 +37,7 @@ def cli() -> None:
     default=lambda: int(os.getenv("E2S_DEFAULT_RADIUS_METERS", "50")),
     show_default=True,
 )
-@click.option("--retention-days", default=30, show_default=True)
+@click.option("--retention-days", default=30, show_default=True, type=int)
 @click.option("--confirm-delete", is_flag=True, help="Allow hard deletes after retention window.")
 @click.option("--apply", is_flag=True, help="Apply changes. Without this flag, dry-run only.")
 def full_cmd(
@@ -71,7 +71,7 @@ def full_cmd(
     default=lambda: int(os.getenv("E2S_DEFAULT_RADIUS_METERS", "50")),
     show_default=True,
 )
-@click.option("--retention-days", default=30, show_default=True)
+@click.option("--retention-days", default=30, show_default=True, type=int)
 @click.option("--confirm-delete", is_flag=True, help="Allow hard deletes after retention window.")
 @click.option("--apply", is_flag=True, help="Apply changes. Without this flag, dry-run only.")
 def daily_cmd(


### PR DESCRIPTION
## Summary
- Ensure `--retention-days` options in `full` and `daily` commands parse integers

## Testing
- `ruff check src/encompass_to_samsara/cli.py --no-fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae3b0e7a788328a4d071a1690fc1a2