### PR TITLE
Handle nested circle geofence in diff and tests

### DIFF
--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -8,8 +8,10 @@ def test_diff_address_returns_only_changes():
         "name": "Old Name",
         "formattedAddress": "123 Main St",
         "geofence": {
-            "radiusMeters": 50,
-            "center": {"latitude": 10.0, "longitude": 20.0},
+            "circle": {
+                "radiusMeters": 50,
+                "center": {"latitude": 10.0, "longitude": 20.0},
+            }
         },
         "tagIds": ["1", "2"],
         "externalIds": {
@@ -25,8 +27,10 @@ def test_diff_address_returns_only_changes():
         "name": "New Name",
         "formattedAddress": "456 Elm St",
         "geofence": {
-            "radiusMeters": 75,
-            "center": {"latitude": 11.0, "longitude": 21.0},
+            "circle": {
+                "radiusMeters": 75,
+                "center": {"latitude": 11.0, "longitude": 21.0},
+            }
         },
         "tagIds": ["1", "3"],
         "externalIds": {
@@ -43,8 +47,10 @@ def test_diff_address_returns_only_changes():
         "name": "New Name",
         "formattedAddress": "456 Elm St",
         "geofence": {
-            "radiusMeters": 75,
-            "center": {"latitude": 11.0, "longitude": 21.0},
+            "circle": {
+                "radiusMeters": 75,
+                "center": {"latitude": 11.0, "longitude": 21.0},
+            }
         },
         "tagIds": ["1", "3"],
         "externalIds": {
@@ -73,12 +79,41 @@ def test_diff_address_preserves_polygon_geofence():
         "name": "New Name",
         "formattedAddress": "123 Main St",
         "geofence": {
-            "radiusMeters": 75,
-            "center": {"latitude": 11.0, "longitude": 21.0},
+            "circle": {
+                "radiusMeters": 75,
+                "center": {"latitude": 11.0, "longitude": 21.0},
+            }
         },
     }
     patch = diff_address(existing, desired)
     assert patch == {"name": "New Name"}
+
+
+def test_diff_address_handles_missing_circle_geofence():
+    from encompass_to_samsara.transform import diff_address
+
+    existing = {
+        "name": "Same Name",
+        "formattedAddress": "123 Main St",
+        # malformed legacy geofence lacking "circle"
+        "geofence": {
+            "radiusMeters": 50,
+            "center": {"latitude": 10.0, "longitude": 20.0},
+        },
+    }
+    desired = {
+        "name": "Same Name",
+        "formattedAddress": "123 Main St",
+        "geofence": {
+            "circle": {
+                "radiusMeters": 60,
+                "center": {"latitude": 11.0, "longitude": 21.0},
+            }
+        },
+    }
+
+    patch = diff_address(existing, desired)
+    assert patch == {"geofence": desired["geofence"]}
 
 
 @pytest.mark.parametrize(
@@ -98,8 +133,10 @@ def test_diff_address_skips_geofence_with_updated_tag(tag_data, desired_tags):
         "name": "Old Name",
         "formattedAddress": "123 Main St",
         "geofence": {
-            "radiusMeters": 50,
-            "center": {"latitude": 10.0, "longitude": 20.0},
+            "circle": {
+                "radiusMeters": 50,
+                "center": {"latitude": 10.0, "longitude": 20.0},
+            }
         },
         **tag_data,
     }
@@ -107,8 +144,10 @@ def test_diff_address_skips_geofence_with_updated_tag(tag_data, desired_tags):
         "name": "New Name",
         "formattedAddress": "123 Main St",
         "geofence": {
-            "radiusMeters": 75,
-            "center": {"latitude": 11.0, "longitude": 21.0},
+            "circle": {
+                "radiusMeters": 75,
+                "center": {"latitude": 11.0, "longitude": 21.0},
+            }
         },
         **desired_tags,
     }

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -24,7 +24,7 @@ def test_payload_includes_scope_and_tags():
     assert payload["externalIds"]["encompass_id"] == "C123"
     assert payload["externalIds"]["ENCOMPASS_MANAGED"] == "1"
     assert "ENCOMPASS_FINGERPRINT" in payload["externalIds"]
-    assert payload["geofence"]["radiusMeters"] == 75
+    assert payload["geofence"]["circle"]["radiusMeters"] == 75
     assert set(payload["tagIds"]) >= {"1","10","20"}
 
 def test_validate_lat_lon():


### PR DESCRIPTION
## Summary
- compare circle-based geofence fields in `diff_address`
- output circle-based geofences from `to_address_payload`
- test geofence diffing, including malformed and polygon cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae4e9d2824832893fea78e8f298708