### PR TITLE
Fix geofence diff to support circle structure

### DIFF
--- a/src/encompass_to_samsara/transform.py
+++ b/src/encompass_to_samsara/transform.py
@@ -209,20 +209,20 @@ def diff_address(existing: dict, desired: dict) -> dict:
     # formatted address
     if (existing.get("formattedAddress") or "") != (desired.get("formattedAddress") or ""):
         patch["formattedAddress"] = desired.get("formattedAddress")
-    # geofence (compare center lat/lon and radius)
+    # geofence (compare circle lat/lon and radius)
     e_geo = existing.get("geofence") or {}
     d_geo = desired.get("geofence") or {}
-    skip_geofence = "polygon" in e_geo or _has_updated_geofence_tag(existing)
+    skip_geofence = bool(e_geo.get("polygon")) or _has_updated_geofence_tag(existing)
     if not skip_geofence:
         if bool(d_geo) != bool(e_geo):
             patch["geofence"] = d_geo or None
         else:
-            e_center = (e_geo.get("center") or {})
-            d_center = (d_geo.get("center") or {})
+            e_circle = e_geo.get("circle") or {}
+            d_circle = d_geo.get("circle") or {}
             if (
-                (e_geo.get("radiusMeters") != d_geo.get("radiusMeters"))
-                or (e_center.get("latitude") != d_center.get("latitude"))
-                or (e_center.get("longitude") != d_center.get("longitude"))
+                e_circle.get("radiusMeters") != d_circle.get("radiusMeters")
+                or e_circle.get("latitude") != d_circle.get("latitude")
+                or e_circle.get("longitude") != d_circle.get("longitude")
             ):
                 patch["geofence"] = d_geo or None
     # externalIds merge (add/replace keys we own, keep others intact on server)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -8,8 +8,11 @@ def test_diff_address_returns_only_changes():
         "name": "Old Name",
         "formattedAddress": "123 Main St",
         "geofence": {
-            "radiusMeters": 50,
-            "center": {"latitude": 10.0, "longitude": 20.0},
+            "circle": {
+                "radiusMeters": 50,
+                "latitude": 10.0,
+                "longitude": 20.0,
+            }
         },
         "tagIds": ["1", "2"],
         "externalIds": {
@@ -25,8 +28,11 @@ def test_diff_address_returns_only_changes():
         "name": "New Name",
         "formattedAddress": "456 Elm St",
         "geofence": {
-            "radiusMeters": 75,
-            "center": {"latitude": 11.0, "longitude": 21.0},
+            "circle": {
+                "radiusMeters": 75,
+                "latitude": 11.0,
+                "longitude": 21.0,
+            }
         },
         "tagIds": ["1", "3"],
         "externalIds": {
@@ -43,8 +49,11 @@ def test_diff_address_returns_only_changes():
         "name": "New Name",
         "formattedAddress": "456 Elm St",
         "geofence": {
-            "radiusMeters": 75,
-            "center": {"latitude": 11.0, "longitude": 21.0},
+            "circle": {
+                "radiusMeters": 75,
+                "latitude": 11.0,
+                "longitude": 21.0,
+            }
         },
         "tagIds": ["1", "3"],
         "externalIds": {
@@ -73,8 +82,11 @@ def test_diff_address_preserves_polygon_geofence():
         "name": "New Name",
         "formattedAddress": "123 Main St",
         "geofence": {
-            "radiusMeters": 75,
-            "center": {"latitude": 11.0, "longitude": 21.0},
+            "circle": {
+                "radiusMeters": 75,
+                "latitude": 11.0,
+                "longitude": 21.0,
+            }
         },
     }
     patch = diff_address(existing, desired)
@@ -98,8 +110,11 @@ def test_diff_address_skips_geofence_with_updated_tag(tag_data, desired_tags):
         "name": "Old Name",
         "formattedAddress": "123 Main St",
         "geofence": {
-            "radiusMeters": 50,
-            "center": {"latitude": 10.0, "longitude": 20.0},
+            "circle": {
+                "radiusMeters": 50,
+                "latitude": 10.0,
+                "longitude": 20.0,
+            }
         },
         **tag_data,
     }
@@ -107,8 +122,11 @@ def test_diff_address_skips_geofence_with_updated_tag(tag_data, desired_tags):
         "name": "New Name",
         "formattedAddress": "123 Main St",
         "geofence": {
-            "radiusMeters": 75,
-            "center": {"latitude": 11.0, "longitude": 21.0},
+            "circle": {
+                "radiusMeters": 75,
+                "latitude": 11.0,
+                "longitude": 21.0,
+            }
         },
         **desired_tags,
     }

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -24,6 +24,7 @@ def test_payload_includes_scope_and_tags():
     assert payload["externalIds"]["encompass_id"] == "C123"
     assert payload["externalIds"]["ENCOMPASS_MANAGED"] == "1"
     assert "ENCOMPASS_FINGERPRINT" in payload["externalIds"]
+    assert set(payload["geofence"].keys()) == {"circle"}
     assert payload["geofence"]["circle"]["radiusMeters"] == 75
     assert payload["geofence"]["circle"]["latitude"] == 30.1
     assert payload["geofence"]["circle"]["longitude"] == -97.7


### PR DESCRIPTION
## Summary
- compare nested `circle` geofence attributes when diffing addresses
- ensure polygon geofences and updated-geofence tags are skipped during diff
- test new circle geofence structure in transform and diff tests

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae5587a6d88328a17d48409e005705