### PR TITLE
Ensure geofence radius stays numeric

### DIFF
--- a/src/encompass_to_samsara/reporting.py
+++ b/src/encompass_to_samsara/reporting.py
@@ -25,7 +25,18 @@ def ensure_out_dir(out_dir: str) -> None:
 def write_jsonl(path: str, actions: list[Action]) -> None:
     with open(path, "w", encoding="utf-8") as f:
         for a in actions:
-            f.write(json.dumps(asdict(a), ensure_ascii=False) + "\n")
+            data = asdict(a)
+            payload = data.get("payload")
+            if isinstance(payload, dict):
+                geo = payload.get("geofence")
+                if isinstance(geo, dict):
+                    circle = geo.get("circle")
+                    if isinstance(circle, dict) and "radiusMeters" in circle:
+                        try:
+                            circle["radiusMeters"] = int(circle["radiusMeters"])
+                        except (TypeError, ValueError):
+                            pass
+            f.write(json.dumps(data, ensure_ascii=False) + "\n")
 
 def write_csv(path: str, rows: list[dict], fieldnames: list[str]) -> None:
     with open(path, "w", encoding="utf-8", newline="") as f:

--- a/tests/test_sync_full.py
+++ b/tests/test_sync_full.py
@@ -222,3 +222,48 @@ def test_full_skip_inactive_status(tmp_path, token_env, base_responses):
         acts = [json.loads(line) for line in f]
     assert acts[0]["kind"] == "skip" and acts[0]["reason"] == "inactive_status"
     assert all(c.request.method == "GET" for c in rsps.calls)
+
+
+def test_actions_radius_meters_int(tmp_path, token_env, base_responses):
+    source_rows = [
+        {
+            "Customer ID": "C1",
+            "Customer Name": "Foo",
+            "Account Status": "Active",
+            "Latitude": "30.1",
+            "Longitude": "-97.7",
+            "Report Company Address": "123 A St",
+            "Location": "Austin",
+            "Company": "JECO",
+            "Customer Type": "Retail",
+        }
+    ]
+    src_csv = tmp_path / "encompass_full.csv"
+    write_csv(src_csv, source_rows)
+
+    wh_csv = tmp_path / "warehouses.csv"
+    with open(wh_csv, "w", encoding="utf-8") as f:
+        f.write("samsara_id,name\n")
+
+    out_dir = tmp_path / "out"
+
+    with base_responses as rsps:
+        rsps.add(responses.GET, f"{API}/addresses", json={"addresses": []}, status=200)
+        rsps.add(responses.POST, f"{API}/addresses", json={"id": "201"}, status=200)
+        client = SamsaraClient(api_token="test-token")
+        run_full(
+            client,
+            encompass_csv=str(src_csv),
+            warehouses_path=str(wh_csv),
+            out_dir=str(out_dir),
+            radius_m=50,
+            apply=True,
+            retention_days=30,
+            confirm_delete=False,
+        )
+
+    with open(out_dir / "actions.jsonl", encoding="utf-8") as f:
+        acts = [json.loads(line) for line in f]
+    create_act = next(a for a in acts if a["kind"] == "create")
+    radius = create_act["payload"]["geofence"]["circle"]["radiusMeters"]
+    assert isinstance(radius, int)


### PR DESCRIPTION
## Summary
- enforce integer `radiusMeters` during JSONL serialization
- add regression test verifying `radiusMeters` remains an `int`

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae69fa0ee88328a46d961b1d1ca071