### PR TITLE
Ensure full sync actions remain isolated

### DIFF
--- a/src/encompass_to_samsara/cli.py
+++ b/src/encompass_to_samsara/cli.py
@@ -51,6 +51,9 @@ def full_cmd(
     apply: bool,
 ) -> None:
     client = SamsaraClient()
+    # Dispatch directly to run_full. All action handling occurs inside run_full
+    # which instantiates its own actions list, ensuring this CLI command
+    # remains stateless and isolated from other subcommands.
     run_full(
         client,
         encompass_csv=encompass_csv,

--- a/src/encompass_to_samsara/sync_full.py
+++ b/src/encompass_to_samsara/sync_full.py
@@ -297,8 +297,9 @@ def run_full(
             state["candidate_deletes"].pop(aid, None)
             state["fingerprints"].pop(aid, None)
 
-    # Write outputs
-    write_jsonl(f"{out_dir}/actions.jsonl", actions)
+    # Write outputs. Pass a copy of the actions list so that serialization
+    # cannot accidentally mutate the in-memory actions collected above.
+    write_jsonl(f"{out_dir}/actions.jsonl", list(actions))
     write_csv(f"{out_dir}/dry_run_diff.csv", dry_rows, ["encompass_id", "name", "action"])
     summary = summarize(actions)
     report_rows = [{"metric": k, "value": v} for k, v in sorted(summary.items())]

--- a/tests/test_cli_full.py
+++ b/tests/test_cli_full.py
@@ -1,0 +1,68 @@
+import csv
+import json
+from click.testing import CliRunner
+import responses
+
+from encompass_to_samsara.cli import cli
+
+API = "https://api.samsara.com"
+
+
+def write_csv(path, rows):
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        if not rows:
+            return
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+
+def test_cli_full_actions_no_delta(tmp_path, base_responses):
+    """Invoke the CLI full subcommand and ensure action reasons are clean."""
+    # Prepare source CSV with one active row
+    source_rows = [{
+        "Customer ID": "C1",
+        "Customer Name": "Foo",
+        "Account Status": "Active",
+        "Latitude": "30.1",
+        "Longitude": "-97.7",
+        "Report Company Address": "123 A St",
+        "Location": "Austin",
+        "Company": "JECO",
+        "Customer Type": "Retail",
+    }]
+    src_csv = tmp_path / "encompass_full.csv"
+    write_csv(src_csv, source_rows)
+
+    # Warehouses denylist (empty)
+    wh_csv = tmp_path / "warehouses.csv"
+    with open(wh_csv, "w", encoding="utf-8") as f:
+        f.write("samsara_id,name\n")
+
+    out_dir = tmp_path / "out"
+    runner = CliRunner()
+
+    with base_responses as rsps:
+        rsps.add(responses.GET, f"{API}/addresses", json={"addresses": []}, status=200)
+        result = runner.invoke(
+            cli,
+            [
+                "full",
+                "--encompass-csv",
+                str(src_csv),
+                "--warehouses",
+                str(wh_csv),
+                "--out-dir",
+                str(out_dir),
+            ],
+            env={"SAMSARA_BEARER_TOKEN": "test-token"},
+        )
+
+    assert result.exit_code == 0, result.output
+
+    # Ensure actions reasons do not start with delta_
+    with open(out_dir / "actions.jsonl", encoding="utf-8") as f:
+        for line in f:
+            reason = json.loads(line)["reason"]
+            assert not reason.startswith("delta_"), reason


### PR DESCRIPTION
## Summary
- Clarify full CLI command dispatches only to `run_full` and keeps action handling isolated
- Guard against action list mutation by passing a copy to `write_jsonl`
- Add integration test invoking the `full` CLI subcommand to ensure no `delta_` reasons leak into actions

## Testing
- `PYTHONPATH=src pytest tests/test_cli_full.py -q`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af0ead730883289e20ca2faf344ba9