### PR TITLE
Normalize geofence schema in actions reporting

### DIFF
--- a/src/encompass_to_samsara/reporting.py
+++ b/src/encompass_to_samsara/reporting.py
@@ -7,6 +7,8 @@ import os
 from dataclasses import dataclass, asdict
 from typing import Any, Dict, List
 
+from .transform import normalize_geofence
+
 LOG = logging.getLogger(__name__)
 
 @dataclass
@@ -28,8 +30,9 @@ def write_jsonl(path: str, actions: list[Action]) -> None:
             data = asdict(a)
             payload = data.get("payload")
             if isinstance(payload, dict):
-                geo = payload.get("geofence")
-                if isinstance(geo, dict):
+                geo = normalize_geofence(payload.get("geofence"))
+                if geo:
+                    payload["geofence"] = geo
                     circle = geo.get("circle")
                     if isinstance(circle, dict) and "radiusMeters" in circle:
                         try:

--- a/tests/test_actions_geofence.py
+++ b/tests/test_actions_geofence.py
@@ -1,0 +1,77 @@
+import csv
+import json
+
+import pytest
+import responses
+
+from encompass_to_samsara.samsara_client import SamsaraClient
+from encompass_to_samsara.sync_daily import run_daily
+from encompass_to_samsara.sync_full import run_full
+
+API = "https://api.samsara.com"
+
+
+def write_csv(path, rows):
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        if not rows:
+            return
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+
+@pytest.mark.parametrize(
+    "sync_func,src_arg",
+    [
+        (run_full, "encompass_csv"),
+        (run_daily, "encompass_delta"),
+    ],
+)
+def test_actions_jsonl_geofence_always_circle(tmp_path, token_env, base_responses, sync_func, src_arg):
+    row = {
+        "Customer ID": "C1",
+        "Customer Name": "Foo",
+        "Account Status": "Active",
+        "Latitude": "30.1",
+        "Longitude": "-97.7",
+        "Report Company Address": "123 A St",
+        "Location": "Austin",
+        "Company": "JECO",
+        "Customer Type": "Retail",
+    }
+    if src_arg == "encompass_delta":
+        row["Action"] = "upsert"
+    src_csv = tmp_path / "src.csv"
+    write_csv(src_csv, [row])
+
+    wh_csv = tmp_path / "warehouses.csv"
+    with open(wh_csv, "w", encoding="utf-8") as f:
+        f.write("samsara_id,name\n")
+
+    out_dir = tmp_path / "out"
+
+    with base_responses as rsps:
+        rsps.add(responses.GET, f"{API}/addresses", json={"addresses": []}, status=200)
+        rsps.add(responses.POST, f"{API}/addresses", json={"id": "101"}, status=200)
+
+        client = SamsaraClient(api_token="test-token")
+        kwargs = {
+            src_arg: str(src_csv),
+            "warehouses_path": str(wh_csv),
+            "out_dir": str(out_dir),
+            "radius_m": 50,
+            "apply": True,
+            "retention_days": 30,
+            "confirm_delete": False,
+        }
+        sync_func(client, **kwargs)
+
+    with open(out_dir / "actions.jsonl", encoding="utf-8") as f:
+        geos = [
+            a["payload"]["geofence"]
+            for a in (json.loads(line) for line in f)
+            if a.get("payload") and a["payload"].get("geofence")
+        ]
+    assert geos and all("circle" in g and "center" not in g for g in geos)
+


### PR DESCRIPTION
## Summary
- normalize any geofence payloads to circle schema when writing actions.jsonl
- add regression test ensuring both sync routines output circle geofences only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1085b4288328bf626217953002d3