### PR TITLE
Normalize tag names before lookup

### DIFF
--- a/src/encompass_to_samsara/tags.py
+++ b/src/encompass_to_samsara/tags.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 from .samsara_client import SamsaraClient
+from .transform import normalize
 
 LOG = logging.getLogger(__name__)
 
@@ -11,7 +12,7 @@ CANDIDATE_DELETE_TAG = "CandidateDelete"
 
 
 def build_tag_index(client: SamsaraClient) -> dict[str, str]:
-    """Return mapping of lowercased tag name -> tag id"""
+    """Return mapping of normalized tag name -> tag id"""
     index: dict[str, str] = {}
     for t in client.list_tags():
         name = (t.get("name") or "").strip()
@@ -20,11 +21,11 @@ def build_tag_index(client: SamsaraClient) -> dict[str, str]:
         tid = str(t.get("id") or t.get("tagId") or "")
         if not tid:
             continue
-        index[name.lower()] = tid
+        index[normalize(name)] = tid
     return index
 
 
 def resolve_tag_id(index: dict[str, str], name: str) -> str | None:
     if not name:
         return None
-    return index.get(name.lower())
+    return index.get(normalize(name))

--- a/src/encompass_to_samsara/transform.py
+++ b/src/encompass_to_samsara/transform.py
@@ -41,8 +41,8 @@ def normalize(s: str | None) -> str:
     if not s:
         return ""
     s2 = s.strip().lower()
-    s2 = RE_SPACES.sub(" ", s2)
     s2 = RE_PUNCT.sub("", s2)
+    s2 = RE_SPACES.sub(" ", s2)
     return s2.strip()
 
 def canonical_address(addr: str | None) -> str:
@@ -158,13 +158,13 @@ def to_address_payload(
 
     tag_ids: list[str] = []
     # scope tag
-    t = tag_name_to_id.get(managed_tag_name.lower())
+    t = tag_name_to_id.get(normalize(managed_tag_name))
     if t:
         tag_ids.append(t)
     # Location & Company tags
     for tag_val in [row.location, row.company]:
         if tag_val:
-            tid = tag_name_to_id.get(tag_val.lower())
+            tid = tag_name_to_id.get(normalize(tag_val))
             if tid and tid not in tag_ids:
                 tag_ids.append(tid)
 


### PR DESCRIPTION
## Summary
- normalize tag names in build_tag_index and lookups
- ensure location and company tags use normalized values
- cover hyphenated location names mapping to tags

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af6bd4a1b88328ba0addd25d860995