### PR TITLE
Sanitize external ID values

### DIFF
--- a/src/encompass_to_samsara/transform.py
+++ b/src/encompass_to_samsara/transform.py
@@ -11,6 +11,7 @@ LOG = logging.getLogger(__name__)
 
 RE_SPACES = re.compile(r"\s+")
 RE_PUNCT = re.compile(r"[^\w\s]")
+RE_EXTID_SANITIZE = re.compile(r"[^A-Za-z0-9@._%+\-]")
 
 REQUIRED_COLUMNS = [
     "Customer ID",
@@ -137,13 +138,18 @@ def normalize_geofence(geo: dict | None) -> dict | None:
     return geo
 
 
+def sanitize_external_id_values(ext: dict[str, Any]) -> dict[str, Any]:
+    """Return copy of ``ext`` with values stripped to allowed characters."""
+    return {k: RE_EXTID_SANITIZE.sub("", str(v)) for k, v in ext.items()}
+
+
 def clean_external_ids(ext: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of ``ext`` with a single canonical Encompass ID key."""
     out = ext.copy()
     eid = out.pop("EncompassId", None) or out.pop("ENCOMPASS_ID", None)
     if eid and "encompass_id" not in out:
         out["encompass_id"] = eid
-    return out
+    return sanitize_external_id_values(out)
 
 def to_address_payload(
     row: SourceRow,
@@ -180,18 +186,19 @@ def to_address_payload(
             }
         )
 
+    external_ids = {
+        "encompass_id": row.encompass_id,
+        "ENCOMPASS_STATUS": row.status,
+        "ENCOMPASS_MANAGED": "1",
+        "ENCOMPASS_FINGERPRINT": fp,
+    }
+    if row.ctype:
+        external_ids["ENCOMPASS_TYPE"] = row.ctype
     payload: dict[str, Any] = {
         "name": row.name,
         "formattedAddress": formatted_addr,
-        "externalIds": {
-            "encompass_id": row.encompass_id,
-            "ENCOMPASS_STATUS": row.status,
-            "ENCOMPASS_MANAGED": "1",
-            "ENCOMPASS_FINGERPRINT": fp,
-        },
+        "externalIds": sanitize_external_id_values(external_ids),
     }
-    if row.ctype:
-        payload["externalIds"]["ENCOMPASS_TYPE"] = row.ctype
 
     if geofence:
         payload["geofence"] = geofence

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -5,6 +5,7 @@ from encompass_to_samsara.transform import (
     normalize,
     to_address_payload,
     validate_lat_lon,
+    clean_external_ids,
 )
 from encompass_to_samsara.tags import build_tag_index
 
@@ -99,3 +100,28 @@ def test_hyphenated_location_maps_to_tag(monkeypatch, client):
     )
     payload = to_address_payload(row, tag_index)
     assert payload["tagIds"] == ["1"]
+
+
+def test_external_ids_are_sanitized():
+    row = SourceRow(
+        encompass_id="ID!123",
+        name="Foo",
+        status="Acti$ve",
+        lat=None,
+        lon=None,
+        address="",
+        location="",
+        company="",
+        ctype="Retail&Store",
+    )
+    payload = to_address_payload(row, {})
+    assert payload["externalIds"]["encompass_id"] == "ID123"
+    assert payload["externalIds"]["ENCOMPASS_STATUS"] == "Active"
+    assert payload["externalIds"]["ENCOMPASS_TYPE"] == "RetailStore"
+
+
+def test_clean_external_ids_sanitizes_values():
+    ext = {"EncompassId": "X@1#2", "Foo": "Bar$"}
+    cleaned = clean_external_ids(ext)
+    assert cleaned["encompass_id"] == "X@12"
+    assert cleaned["Foo"] == "Bar"


### PR DESCRIPTION
## Summary
- Strip disallowed characters from `externalIds` using new `sanitize_external_id_values` helper
- Normalize external IDs consistently in `clean_external_ids`
- Sanitize external IDs when building address payloads
- Add tests covering sanitization behavior

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8fb8e15c832882e71314b64223e8