### PR TITLE
Sanitize ctype before generating address payload

### DIFF
--- a/src/encompass_to_samsara/transform.py
+++ b/src/encompass_to_samsara/transform.py
@@ -191,7 +191,7 @@ def to_address_payload(
         },
     }
     if row.ctype:
-        payload["externalIds"]["ENCOMPASS_TYPE"] = row.ctype
+        payload["externalIds"]["ENCOMPASS_TYPE"] = RE_PUNCT.sub("", row.ctype)
 
     if geofence:
         payload["geofence"] = geofence

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -40,6 +40,27 @@ def test_payload_includes_scope_and_tags():
     assert set(payload.get("tagIds", [])) >= {"1","10","20"}
 
 
+def test_ctype_sanitized():
+    row = SourceRow(
+        encompass_id="C100",
+        name="Foo Store",
+        status="Active",
+        lat=None,
+        lon=None,
+        address="",
+        location="",
+        company="",
+        ctype="Convenience*",
+    )
+    payload = to_address_payload(row, {})
+    ext = payload["externalIds"]
+    assert ext["ENCOMPASS_TYPE"] == "Convenience"
+    assert ext["encompass_id"] == "C100"
+    assert ext["ENCOMPASS_STATUS"] == "Active"
+    assert ext["ENCOMPASS_MANAGED"] == "1"
+    assert "ENCOMPASS_FINGERPRINT" in ext
+
+
 def test_invalid_coordinates_skip_geofence():
     row = SourceRow(
         encompass_id="C999",


### PR DESCRIPTION
## Summary
- Strip punctuation from customer type when building address payloads
- Test that `ENCOMPASS_TYPE` removes stars and preserves other external IDs

## Testing
- `PYTHONPATH=src pytest tests/test_transform.py::test_ctype_sanitized -q`
- `PYTHONPATH=src pytest tests/test_transform.py -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8fb9ccac832887dee79b67c1270b