### PR TITLE
Sanitize ENCOMPASS_TYPE in address payloads

### DIFF
--- a/src/encompass_to_samsara/transform.py
+++ b/src/encompass_to_samsara/transform.py
@@ -191,7 +191,9 @@ def to_address_payload(
         },
     }
     if row.ctype:
-        payload["externalIds"]["ENCOMPASS_TYPE"] = row.ctype
+        ctype = RE_PUNCT.sub("", row.ctype).strip()
+        if ctype:
+            payload["externalIds"]["ENCOMPASS_TYPE"] = ctype
 
     if geofence:
         payload["geofence"] = geofence

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -99,3 +99,24 @@ def test_hyphenated_location_maps_to_tag(monkeypatch, client):
     )
     payload = to_address_payload(row, tag_index)
     assert payload["tagIds"] == ["1"]
+
+
+def test_to_address_payload_strips_invalid_chars_from_ctype():
+    row = SourceRow(
+        encompass_id="C42",
+        name="Foo",
+        status="Active",
+        lat=None,
+        lon=None,
+        address="",
+        location="",
+        company="",
+        ctype="Convenience*",
+    )
+    payload = to_address_payload(row, {})
+    ext = payload["externalIds"]
+    assert ext["ENCOMPASS_TYPE"] == "Convenience"
+    assert ext["encompass_id"] == "C42"
+    assert ext["ENCOMPASS_STATUS"] == "Active"
+    assert ext["ENCOMPASS_MANAGED"] == "1"
+    assert ext["ENCOMPASS_FINGERPRINT"] == compute_fingerprint("Foo", "Active", "")


### PR DESCRIPTION
## Summary
- strip non-alphanumeric characters from ENCOMPASS_TYPE before sending to Samsara
- add regression test for ctype sanitization in to_address_payload

## Testing
- `PYTHONPATH=src pytest tests/test_transform.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68afb90765108328b57ad15b2457dc22