### PR TITLE
Normalize EncompassId handling and relax external ID value limit

### DIFF
--- a/src/encompass_to_samsara/matcher.py
+++ b/src/encompass_to_samsara/matcher.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import math
 
-from .transform import canonical_address, normalize
+from .transform import canonical_address, clean_external_ids, normalize
 
 LOG = logging.getLogger(__name__)
 
@@ -21,14 +21,8 @@ def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
 def index_addresses_by_external_id(addresses: list[dict]) -> dict[str, dict]:
     idx: dict[str, dict] = {}
     for a in addresses:
-        ext = a.get("externalIds") or {}
-        eid = (
-            ext.get("encompassid")
-            or ext.get("ENCOMPASSID")
-            or ext.get("EncompassId")
-            or ext.get("ENCOMPASS_ID")
-            or ext.get("encompass_id")
-        )
+        ext = clean_external_ids(a.get("externalIds") or {})
+        eid = ext.get("EncompassId")
         if eid:
             idx[str(eid)] = a
     return idx

--- a/src/encompass_to_samsara/safety.py
+++ b/src/encompass_to_samsara/safety.py
@@ -4,6 +4,8 @@ import csv
 import logging
 from datetime import UTC, datetime, timedelta
 
+from .transform import clean_external_ids
+
 LOG = logging.getLogger(__name__)
 
 def load_warehouses(path: str) -> tuple[set[str], set[str]]:
@@ -49,14 +51,8 @@ def is_warehouse(address: dict, warehouse_ids: set[str], warehouse_names_lc: set
     return False
 
 def is_managed(address: dict, managed_tag_id: str | None) -> bool:
-    ext = address.get("externalIds") or {}
-    if (
-        ext.get("encompassid")
-        or ext.get("ENCOMPASSID")
-        or ext.get("EncompassId")
-        or ext.get("ENCOMPASS_ID")
-        or ext.get("encompass_id")
-    ):
+    ext = clean_external_ids(address.get("externalIds") or {})
+    if ext.get("EncompassId"):
         return True
     # Look for ManagedBy tag
     if managed_tag_id:

--- a/src/encompass_to_samsara/sync_full.py
+++ b/src/encompass_to_samsara/sync_full.py
@@ -21,13 +21,7 @@ LOG = logging.getLogger(__name__)
 
 def _ext_encompass_id(ext: dict[str, Any]) -> str | None:
     """Return the Encompass external ID if present."""
-    return (
-        ext.get("encompassid")
-        or ext.get("ENCOMPASSID")
-        or ext.get("EncompassId")
-        or ext.get("ENCOMPASS_ID")
-        or ext.get("encompass_id")
-    )
+    return clean_external_ids(ext).get("EncompassId")
 
 
 def run_full(
@@ -151,7 +145,7 @@ def run_full(
                 # inject ext and tags
                 diff["externalIds"] = clean_external_ids(existing.get("externalIds") or {})
                 diff["externalIds"]["encompassmanaged"] = "1"
-                diff["externalIds"]["encompassid"] = r.encompass_id
+                diff["externalIds"]["EncompassId"] = r.encompass_id
             if needs_scope:
                 # ensure tagIds
                 d_tags = desired.get("tagIds") or []

--- a/tests/test_daily.py
+++ b/tests/test_daily.py
@@ -55,7 +55,7 @@ def test_daily_upsert_skip_when_unchanged(tmp_path, token_env, base_responses):
             "name": "Foo",
             "formattedAddress": "123 A St",
             "externalIds": {
-                "encompassid": "C1",
+                "EncompassId": "C1",
                 "encompassstatus": "Active",
                 "encompassmanaged": "1",
                 "fingerprint": fp,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -36,7 +36,7 @@ def test_diff_address_returns_only_changes():
         },
         "tagIds": ["1", "3"],
         "externalIds": {
-            "encompassid": "abc",
+            "EncompassId": "abc",
             "encompassstatus": "Inactive",
             "encompassmanaged": "1",
             "fingerprint": "fp2",
@@ -57,7 +57,7 @@ def test_diff_address_returns_only_changes():
         },
         "tagIds": ["1", "3"],
         "externalIds": {
-            "encompassid": "abc",
+            "EncompassId": "abc",
             "encompassstatus": "Inactive",
             "encompassmanaged": "1",
             "fingerprint": "fp2",

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -29,14 +29,14 @@ def test_export_addresses(monkeypatch, tmp_path):
             "id": "100",
             "name": "Foo",
             "formattedAddress": "123 A St",
-            "externalIds": {"encompassid": "E1"},
+            "externalIds": {"EncompassId": "E1"},
             "tagIds": ["1"],
         },
         {
             "id": "200",
             "name": "Bar",
             "formattedAddress": "456 B St",
-            "externalIds": {"encompassid": "E2"},
+            "externalIds": {"EncompassId": "E2"},
             "tagIds": ["2"],
         },
     ]

--- a/tests/test_sync_full.py
+++ b/tests/test_sync_full.py
@@ -174,7 +174,7 @@ def test_reuse_address_by_name(tmp_path, token_env, base_responses):
         if isinstance(req_body, bytes):
             req_body = req_body.decode()
         body = json.loads(req_body)
-        assert body["externalIds"]["encompassid"] == "C1"
+        assert body["externalIds"]["EncompassId"] == "C1"
 
     with open(out_dir / "actions.jsonl", encoding="utf-8") as f:
         acts = [json.loads(line) for line in f]


### PR DESCRIPTION
## Summary
- Map Encompass data to `EncompassId` external ID and drop legacy `encompassid`
- Only enforce 32-char limit on external ID keys; allow full-length values
- Adjust matcher, safety checks, and tests for new external ID semantics

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d202656c8328880b89b103b547e5