### PR TITLE
Remove deprecated Encompass status external IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ sync-e2s daily   --encompass-delta data/encompass_delta.csv   --warehouses data/
 - `Customer Name` → `name`
 - `Report Address` (no company name) → `formattedAddress` (composed if needed)
 - `Latitude`,`Longitude` → geofence circle (default radius 50 m; configurable)
-- `Account Status` → `externalIds.encompassstatus`
+- `Account Status` → used to compute a fingerprint (not stored)
 - `Location` → **Tag** (resolved via List Tags)
 - `Company` → **Tag** (resolved via List Tags)
 - `Customer Type` → ignored (optional: `externalIds.ENCOMPASS_TYPE`)
-- Scope markers: Tag **ManagedBy:EncompassSync** **and** `externalIds.encompassmanaged="1"`
+- Scope marker: Tag **ManagedBy:EncompassSync**
 - Fingerprint: `externalIds.fingerprint = sha256(normalize(name) + "|" + normalize(account_status) + "|" + normalize(formattedAddress))`
 
 ### External ID requirements
@@ -85,8 +85,6 @@ sending to the API.
 Canonical keys used by this tool:
 
 - `encompassid` – primary customer identifier
-- `encompassstatus`
-- `encompassmanaged`
 - `fingerprint`
 
 Sanitization & backward compatibility:
@@ -106,8 +104,6 @@ safe_id = re.sub(r"[^A-Za-z0-9_.:-]", "_", raw_id)[:32]
 payload = {
     "externalIds": {
         "encompassid": safe_id,
-        "encompassstatus": "ACTIVE",
-        "encompassmanaged": "1",
     }
 }
 ```

--- a/src/encompass_to_samsara.egg-info/PKG-INFO
+++ b/src/encompass_to_samsara.egg-info/PKG-INFO
@@ -18,7 +18,7 @@ Requires-Dist: responses>=0.25.3; extra == "dev"
 Requires-Dist: ruff>=0.5.7; extra == "dev"
 Dynamic: license-file
 
-# Encompass → Samsara Sync (`sync-e2s`)
+# Samsara Customer Sync
 
 A production-ready Python 3.11+ CLI that keeps **Samsara Addresses** in lockstep with **Encompass**
 (Encompass is the source of truth). Supports a **one-time full refresh** and **daily incremental**
@@ -36,7 +36,7 @@ sync. Safe-by-default (dry-run), idempotent (fingerprints), auditable (reports +
 ```bash
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
-cp .env.example .env   # fill token
+cp .env.example .env   # set SAMSARA_BEARER_TOKEN
 make test              # run tests
 make full-dry          # dry-run full refresh using sample paths
 # If the diff looks good:
@@ -47,8 +47,17 @@ make full-apply        # applies changes (and allows deletes per flags)
 
 Create a `.env` or export environment variables:
 
-- `SAMSARA_API_TOKEN` (required): API token for Samsara.
+- `SAMSARA_BEARER_TOKEN` (required): API token for Samsara.
 - `E2S_DEFAULT_RADIUS_METERS` (optional, default 50): geofence radius for new/updated addresses.
+
+### Export current Samsara addresses
+
+```bash
+export SAMSARA_BEARER_TOKEN=your_token
+python -m encompass_to_samsara.scripts.export_addresses
+```
+
+The script writes all existing Samsara addresses to `addresses.json`.
 
 ### CLI
 
@@ -70,6 +79,7 @@ sync-e2s daily   --encompass-delta data/encompass_delta.csv   --warehouses data/
 
 1. **Full Encompass CSV** with columns:
    `Customer ID, Customer Name, Account Status, Latitude, Longitude, Report Address, Location, Company, Customer Type`
+   - `Report Address` values should exclude company names
 2. **Daily delta CSV** (same columns, optional `Action` = `upsert|delete`)
 3. **`warehouses.csv`** (or `.yaml`) list of Samsara IDs/names never to modify/delete.
 
@@ -77,18 +87,51 @@ sync-e2s daily   --encompass-delta data/encompass_delta.csv   --warehouses data/
 
 - `Customer ID` → `externalIds.encompassid` (required)
 - `Customer Name` → `name`
-- `Report Address` → `formattedAddress` (composed if needed)
-- `Latitude`,`Longitude` → geofence center (default radius 50 m; configurable)
-- `Account Status` → `externalIds.encompassstatus`
+- `Report Address` (no company name) → `formattedAddress` (composed if needed)
+- `Latitude`,`Longitude` → geofence circle (default radius 50 m; configurable)
+- `Account Status` → used to compute a fingerprint (not stored)
 - `Location` → **Tag** (resolved via List Tags)
 - `Company` → **Tag** (resolved via List Tags)
 - `Customer Type` → ignored (optional: `externalIds.ENCOMPASS_TYPE`)
-- Scope markers: Tag **ManagedBy:EncompassSync** **and** `externalIds.encompassmanaged="1"`
+- Scope marker: Tag **ManagedBy:EncompassSync**
 - Fingerprint: `externalIds.fingerprint = sha256(normalize(name) + "|" + normalize(account_status) + "|" + normalize(formattedAddress))`
+
+### External ID requirements
+
+Samsara restricts each `externalIds` key and value to **32 characters** from the set
+`[A-Za-z0-9_.:-]`. Values outside this set should be sanitized or replaced before
+sending to the API.
+
+Canonical keys used by this tool:
+
+- `encompassid` – primary customer identifier
+- `fingerprint`
+
+Sanitization & backward compatibility:
+
+- The CLI normalizes legacy keys `EncompassId` and `ENCOMPASS_ID` to the canonical
+  `encompassid` and preserves other external IDs intact.
+- When indexing existing addresses, all three key variants are recognized so older
+  records remain discoverable.
+
+Usage example for a compliant external ID:
+
+```python
+import re
+
+raw_id = "ACME Store #1"
+safe_id = re.sub(r"[^A-Za-z0-9_.:-]", "_", raw_id)[:32]
+payload = {
+    "externalIds": {
+        "encompassid": safe_id,
+    }
+}
+```
 
 ### Safety rails
 
 - Only touch addresses with `externalIds.encompassid` or tag `ManagedBy:EncompassSync`.
+- Customers with `Account Status` `INACTIVE` are ignored unless explicitly deleted.
 - Two-step delete: tag `CandidateDelete`; hard-delete only with `--confirm-delete` **and**
   after retention window.
 - Never touch entries in `warehouses.csv` (denylist of Samsara IDs/names).

--- a/src/encompass_to_samsara/sync_full.py
+++ b/src/encompass_to_samsara/sync_full.py
@@ -137,14 +137,11 @@ def run_full(
                         tag_ids.append(str(t))
             if managed_tag_id and managed_tag_id not in tag_ids:
                 needs_scope = True
-            if ext.get("encompassmanaged") != "1":
-                needs_scope = True
             if _ext_encompass_id(ext) != r.encompass_id:
                 needs_scope = True
             if needs_scope and "externalIds" not in diff:
                 # inject ext and tags
                 diff["externalIds"] = clean_external_ids(existing.get("externalIds") or {})
-                diff["externalIds"]["encompassmanaged"] = "1"
                 diff["externalIds"]["EncompassId"] = r.encompass_id
             if needs_scope:
                 # ensure tagIds

--- a/src/encompass_to_samsara/transform.py
+++ b/src/encompass_to_samsara/transform.py
@@ -244,13 +244,9 @@ def clean_external_ids(ext: dict[str, Any]) -> dict[str, Any]:
     if eid is not None:
         out["EncompassId"] = eid
 
-    status = out.pop("encompass_status", None)
-    if status and "encompassstatus" not in out:
-        out["encompassstatus"] = status
-
-    managed = out.pop("encompass_managed", None)
-    if managed and "encompassmanaged" not in out:
-        out["encompassmanaged"] = managed
+    # Drop deprecated keys
+    out.pop("encompass_status", None)
+    out.pop("encompass_managed", None)
 
     fp = out.pop("encompass_fingerprint", None) or out.pop("fingerprint", None)
     if fp and "fingerprint" not in out:
@@ -300,8 +296,6 @@ def to_address_payload(
 
     ext_ids = {
         "EncompassId": sanitize_external_id_value(row.encompass_id),
-        "encompassstatus": sanitize_external_id_value(row.status),
-        "encompassmanaged": sanitize_external_id_value("1"),
         "fingerprint": sanitize_external_id_value(fp),
     }
     payload["externalIds"] = {k: v for k, v in ext_ids.items() if v is not None}
@@ -391,8 +385,6 @@ def diff_address(existing: dict, desired: dict) -> dict:
     ext_patch = {}
     for k in [
         "EncompassId",
-        "encompassstatus",
-        "encompassmanaged",
         "fingerprint",
     ]:
         if k in d_ext and e_ext.get(k) != d_ext.get(k):

--- a/tests/test_daily.py
+++ b/tests/test_daily.py
@@ -56,8 +56,6 @@ def test_daily_upsert_skip_when_unchanged(tmp_path, token_env, base_responses):
             "formattedAddress": "123 A St",
             "externalIds": {
                 "EncompassId": "C1",
-                "encompassstatus": "Active",
-                "encompassmanaged": "1",
                 "fingerprint": fp,
             },
         },

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -17,8 +17,6 @@ def test_diff_address_returns_only_changes():
         "tagIds": ["1", "2"],
         "externalIds": {
             "EncompassId": "abc",
-            "ENCOMPASS_STATUS": "Active",
-            "ENCOMPASS_MANAGED": "1",
             "ENCOMPASS_FINGERPRINT": "fp1",
             "OTHER": "keep",
         },
@@ -37,8 +35,6 @@ def test_diff_address_returns_only_changes():
         "tagIds": ["1", "3"],
         "externalIds": {
             "EncompassId": "abc",
-            "encompassstatus": "Inactive",
-            "encompassmanaged": "1",
             "fingerprint": "fp2",
             "encompass_type": "Retail",
             "other": "keep",
@@ -58,8 +54,6 @@ def test_diff_address_returns_only_changes():
         "tagIds": ["1", "3"],
         "externalIds": {
             "EncompassId": "abc",
-            "encompassstatus": "Inactive",
-            "encompassmanaged": "1",
             "fingerprint": "fp2",
             "encompass_type": "Retail",
             "other": "keep",


### PR DESCRIPTION
## Summary
- drop `encompassstatus` and `encompassmanaged` from generated address payloads and diff logic
- rely solely on ManagedBy tag for scope and update docs accordingly
- adjust tests for absence of deprecated external IDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f93730288328b528f191376f28a1