### PR TITLE
Use unique delete markers for address quarantine

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ Codex automatically merges agent guidance from the files in `codex/` and your
 > **Note**: The tag **CandidateDelete** is used to quarantine orphans.
 > Ensure a Tag named exactly `CandidateDelete` exists in Samsara (the CLI cannot create tags
 > – only List Tags is allowed by requirements). If missing, the tool falls back to setting
-> `externalIds.ENCOMPASS_DELETE_CANDIDATE="1"` and logs a warning.
+> `externalIds.ENCOMPASS_DELETE_CANDIDATE="<timestamp>-<addressId>"` and logs a warning.

--- a/src/encompass_to_samsara.egg-info/PKG-INFO
+++ b/src/encompass_to_samsara.egg-info/PKG-INFO
@@ -182,4 +182,4 @@ Codex automatically merges agent guidance from the files in `codex/` and your
 > **Note**: The tag **CandidateDelete** is used to quarantine orphans.
 > Ensure a Tag named exactly `CandidateDelete` exists in Samsara (the CLI cannot create tags
 > – only List Tags is allowed by requirements). If missing, the tool falls back to setting
-> `externalIds.ENCOMPASS_DELETE_CANDIDATE="1"` and logs a warning.
+> `externalIds.ENCOMPASS_DELETE_CANDIDATE="<timestamp>-<addressId>"` and logs a warning.

--- a/src/encompass_to_samsara/sync_daily.py
+++ b/src/encompass_to_samsara/sync_daily.py
@@ -101,8 +101,9 @@ def run_daily(
                         )
                 else:
                     ext = clean_external_ids(existing.get("externalIds") or {})
-                    if ext.get("ENCOMPASS_DELETE_CANDIDATE") != "1":
-                        patch = {"externalIds": ext | {"ENCOMPASS_DELETE_CANDIDATE": "1"}}
+                    if "encompass_delete_candidate" not in ext:
+                        marker = f"{now_utc_iso()[:19].replace(':', '').replace('-', '')}-{aid}"
+                        patch = {"externalIds": ext | {"ENCOMPASS_DELETE_CANDIDATE": marker}}
                         if apply:
                             client.patch_address(aid, patch)
                         actions.append(

--- a/src/encompass_to_samsara/sync_full.py
+++ b/src/encompass_to_samsara/sync_full.py
@@ -258,8 +258,9 @@ def run_full(
         else:
             # fallback to externalIds marker
             ext2 = clean_external_ids(addr.get("externalIds") or {})
-            if ext2.get("ENCOMPASS_DELETE_CANDIDATE") != "1":
-                patch = {"externalIds": ext2 | {"ENCOMPASS_DELETE_CANDIDATE": "1"}}
+            if "encompass_delete_candidate" not in ext2:
+                marker = f"{now_utc_iso()[:19].replace(':', '').replace('-', '')}-{aid}"
+                patch = {"externalIds": ext2 | {"ENCOMPASS_DELETE_CANDIDATE": marker}}
                 if apply:
                     client.patch_address(aid, patch)
                 actions.append(

--- a/tests/test_daily.py
+++ b/tests/test_daily.py
@@ -130,3 +130,186 @@ def test_daily_skip_inactive_status(tmp_path, token_env, base_responses):
     with open(out_dir / "actions.jsonl", encoding="utf-8") as f:
         acts = [json.loads(line) for line in f]
     assert any(a["kind"] == "skip" and a["reason"] == "inactive_status" for a in acts)
+
+
+def test_delete_marker_unique_and_by_address(tmp_path, token_env, monkeypatch):
+    delta_rows = [
+        {
+            "Customer ID": "C1",
+            "Customer Name": "Foo",
+            "Account Status": "Active",
+            "Latitude": "30.1",
+            "Longitude": "-97.7",
+            "Report Address": "123 A St",
+            "Location": "Austin",
+            "Company": "JECO",
+            "Customer Type": "Retail",
+            "Action": "delete",
+        },
+        {
+            "Customer ID": "C2",
+            "Customer Name": "Bar",
+            "Account Status": "Active",
+            "Latitude": "30.2",
+            "Longitude": "-97.8",
+            "Report Address": "456 B St",
+            "Location": "Austin",
+            "Company": "JECO",
+            "Customer Type": "Retail",
+            "Action": "delete",
+        },
+    ]
+    d_csv = tmp_path / "encompass_delta.csv"
+    write_csv(d_csv, delta_rows)
+
+    wh_csv = tmp_path / "warehouses.csv"
+    with open(wh_csv, "w", encoding="utf-8") as f:
+        f.write("samsara_id,name\n")
+
+    out_dir = tmp_path / "out"
+
+    samsara_addresses = [
+        {
+            "id": "300",
+            "name": "Foo",
+            "formattedAddress": "123 A St",
+            "externalIds": {"EncompassId": "C1"},
+            "tagIds": ["1"],
+        },
+        {
+            "id": "301",
+            "name": "Bar",
+            "formattedAddress": "456 B St",
+            "externalIds": {"EncompassId": "C2"},
+            "tagIds": ["1"],
+        },
+    ]
+
+    monkeypatch.setattr(
+        "encompass_to_samsara.sync_daily.now_utc_iso",
+        lambda: "2024-08-29T12:34:56Z",
+    )
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            f"{API}/tags",
+            json={"tags": [{"id": "1", "name": "ManagedBy:EncompassSync"}]},
+            status=200,
+        )
+        rsps.add(
+            responses.GET,
+            f"{API}/addresses",
+            json={"addresses": samsara_addresses},
+            status=200,
+        )
+        rsps.add(
+            responses.PATCH,
+            f"{API}/addresses/300",
+            json={"id": "300"},
+            status=200,
+        )
+        rsps.add(
+            responses.PATCH,
+            f"{API}/addresses/301",
+            json={"id": "301"},
+            status=200,
+        )
+
+        client = SamsaraClient(api_token="test-token")
+        run_daily(
+            client,
+            encompass_delta=str(d_csv),
+            warehouses_path=str(wh_csv),
+            out_dir=str(out_dir),
+            radius_m=50,
+            apply=True,
+            retention_days=30,
+            confirm_delete=False,
+        )
+
+        patch_calls = [c for c in rsps.calls if c.request.method == "PATCH"]
+        assert len(patch_calls) == 2
+        markers = []
+        for call in patch_calls:
+            aid = call.request.url.rsplit("/", 1)[-1]
+            body = call.request.body
+            if isinstance(body, bytes):
+                body = body.decode()
+            payload = json.loads(body)
+            val = payload["externalIds"]["ENCOMPASS_DELETE_CANDIDATE"]
+            assert val == f"20240829T123456-{aid}"
+            markers.append(val)
+        assert markers[0] != markers[1]
+
+
+def test_no_patch_when_marker_exists(tmp_path, token_env, monkeypatch):
+    delta_rows = [
+        {
+            "Customer ID": "C1",
+            "Customer Name": "Foo",
+            "Account Status": "Active",
+            "Latitude": "30.1",
+            "Longitude": "-97.7",
+            "Report Address": "123 A St",
+            "Location": "Austin",
+            "Company": "JECO",
+            "Customer Type": "Retail",
+            "Action": "delete",
+        }
+    ]
+    d_csv = tmp_path / "encompass_delta.csv"
+    write_csv(d_csv, delta_rows)
+
+    wh_csv = tmp_path / "warehouses.csv"
+    with open(wh_csv, "w", encoding="utf-8") as f:
+        f.write("samsara_id,name\n")
+
+    out_dir = tmp_path / "out"
+
+    samsara_addresses = [
+        {
+            "id": "300",
+            "name": "Foo",
+            "formattedAddress": "123 A St",
+            "externalIds": {
+                "EncompassId": "C1",
+                "ENCOMPASS_DELETE_CANDIDATE": "20240829T123456-300",
+            },
+            "tagIds": ["1"],
+        }
+    ]
+
+    monkeypatch.setattr(
+        "encompass_to_samsara.sync_daily.now_utc_iso",
+        lambda: "2024-08-29T12:34:56Z",
+    )
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            f"{API}/tags",
+            json={"tags": [{"id": "1", "name": "ManagedBy:EncompassSync"}]},
+            status=200,
+        )
+        rsps.add(
+            responses.GET,
+            f"{API}/addresses",
+            json={"addresses": samsara_addresses},
+            status=200,
+        )
+
+        client = SamsaraClient(api_token="test-token")
+        run_daily(
+            client,
+            encompass_delta=str(d_csv),
+            warehouses_path=str(wh_csv),
+            out_dir=str(out_dir),
+            radius_m=50,
+            apply=True,
+            retention_days=30,
+            confirm_delete=False,
+        )
+
+        patch_calls = [c for c in rsps.calls if c.request.method == "PATCH"]
+        assert len(patch_calls) == 0


### PR DESCRIPTION
## Summary
- generate a unique delete marker using timestamp and address ID
- avoid redundant patches when delete marker already exists
- document fallback marker format and add unit tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2166feeb88328b99ca2b32bb807f6