### PR TITLE
feat(cli): add API rate limit configuration option

### DIFF
--- a/src/encompass_to_samsara/samsara_client.py
+++ b/src/encompass_to_samsara/samsara_client.py
@@ -36,6 +36,7 @@ class SamsaraClient:
         retry: RetryConfig | None = None,
         min_interval: float = 0.0,  # optional client-side throttle between calls
         timeout: float = 30.0,
+        rate_limits: dict[str, Any] | None = None,
     ) -> None:
         token = api_token or os.getenv("SAMSARA_BEARER_TOKEN")
         if not token:
@@ -52,7 +53,13 @@ class SamsaraClient:
         )
         self.retry = retry or RetryConfig()
         self.min_interval = min_interval
+        if rate_limits and "min_interval" in rate_limits:
+            try:
+                self.min_interval = float(rate_limits["min_interval"])
+            except (TypeError, ValueError):
+                LOG.warning("Invalid min_interval in rate_limits config: %r", rate_limits["min_interval"])
         self.timeout = timeout
+        self.rate_limits = rate_limits or {}
         self._last_call = 0.0
 
     # --------------- Core HTTP ---------------

--- a/tests/test_cli_rate_config.py
+++ b/tests/test_cli_rate_config.py
@@ -1,0 +1,44 @@
+import json
+from click.testing import CliRunner
+from encompass_to_samsara.cli import cli
+
+
+def test_cli_passes_rate_config(tmp_path, monkeypatch):
+    cfg = tmp_path / 'rate.json'
+    cfg.write_text(json.dumps({'min_interval': 0.5}))
+    # required files for CLI
+    enc_csv = tmp_path / 'encompass.csv'
+    enc_csv.write_text('header\n')
+    wh_csv = tmp_path / 'warehouses.csv'
+    wh_csv.write_text('samsara_id,name\n')
+    out_dir = tmp_path / 'out'
+
+    captured = {}
+
+    class DummyClient:
+        def __init__(self, **kwargs):
+            captured['kwargs'] = kwargs
+
+    def fake_run_full(client, **kwargs):
+        return None
+
+    monkeypatch.setattr('encompass_to_samsara.cli.SamsaraClient', DummyClient)
+    monkeypatch.setattr('encompass_to_samsara.cli.run_full', fake_run_full)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            '--api-rate-config',
+            str(cfg),
+            'full',
+            '--encompass-csv',
+            str(enc_csv),
+            '--warehouses',
+            str(wh_csv),
+            '--out-dir',
+            str(out_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured['kwargs'].get('rate_limits') == {'min_interval': 0.5}


### PR DESCRIPTION
## Summary
- add `--api-rate-config` option to CLI and load JSON rate limit settings
- pass loaded config to `SamsaraClient`
- support optional `rate_limits` in `SamsaraClient`
- test CLI rate config option

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b72c658e8c8328a8e6717885791bc7