### PR TITLE
Add debug logging for API rate limit delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ payload = {
   after retention window.
 - Never touch entries in `warehouses.csv` (denylist of Samsara IDs/names).
 - Retries/backoff on 429/5xx with exponential backoff + jitter; UTC timestamps; logs retries.
+- Configurable per-endpoint rate limiting; delays are logged at DEBUG with the HTTP method and path.
 
 ### Reports (written to `./output/`)
 


### PR DESCRIPTION
## Summary
- add global and per-endpoint rate limit tracking with debug log messages describing delay duration
- document debug logging for rate-limit delays

## Testing
- `make lint` *(fails: E501 line length in unrelated files)*
- `ruff check src/encompass_to_samsara/samsara_client.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b72e490b50832892fa59ab062d66f7