### PR TITLE
Ensure geofence always included in address payload

### DIFF
--- a/src/encompass_to_samsara/transform.py
+++ b/src/encompass_to_samsara/transform.py
@@ -277,17 +277,14 @@ def to_address_payload(
             if tid and tid not in tag_ids:
                 tag_ids.append(tid)
 
-    geofence = None
+    circle = {"radiusMeters": radius_m}
     if validate_lat_lon(row.lat, row.lon):
-        geofence = normalize_geofence(
-            {
-                "circle": {
-                    "latitude": row.lat,
-                    "longitude": row.lon,
-                    "radiusMeters": radius_m,
-                }
-            }
-        )
+        circle["latitude"] = row.lat
+        circle["longitude"] = row.lon
+    geofence = normalize_geofence({"circle": circle})
+    circle_norm = geofence.get("circle") if isinstance(geofence, dict) else {}
+    if isinstance(circle_norm, dict):
+        geofence["circle"] = {k: v for k, v in circle_norm.items() if v is not None}
 
     payload: dict[str, Any] = {
         "name": row.name,
@@ -300,8 +297,7 @@ def to_address_payload(
     }
     payload["externalIds"] = {k: v for k, v in ext_ids.items() if v is not None}
 
-    if geofence:
-        payload["geofence"] = geofence
+    payload["geofence"] = geofence
     if tag_ids:
         payload["tagIds"] = tag_ids
     return payload

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -56,7 +56,9 @@ def test_invalid_coordinates_skip_geofence():
         ctype="Retail",
     )
     payload = to_address_payload(row, {})
-    assert "geofence" not in payload
+    circle = payload["geofence"]["circle"]
+    assert circle["radiusMeters"] == 50
+    assert "latitude" not in circle and "longitude" not in circle
 
 def test_validate_lat_lon():
     assert validate_lat_lon(0,0)


### PR DESCRIPTION
## Summary
- Always attach a geofence circle when generating address payloads; coordinates are added only if valid.
- Update test to expect geofence with only radius when coordinates are missing.

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b74e5cf328832894f1191c75e1213a