### PR TITLE
feat: resilient upserts and progress bars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "python-dotenv>=1.0.1",
   "PyYAML>=6.0.2",
   "pytz>=2024.1",
+  "tqdm>=4.66",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ requests>=2.32.3
 python-dotenv>=1.0.1
 PyYAML>=6.0.2
 pytz>=2024.1
+tqdm>=4.66
 pytest>=8.1.1
 responses>=0.25.3
 ruff>=0.5.7

--- a/src/encompass_to_samsara/cli.py
+++ b/src/encompass_to_samsara/cli.py
@@ -57,6 +57,12 @@ def cli(ctx: click.Context, api_rate_config: str | None) -> None:
 @click.option("--retention-days", default=30, show_default=True, type=int)
 @click.option("--confirm-delete", is_flag=True, help="Allow hard deletes after retention window.")
 @click.option("--apply", is_flag=True, help="Apply changes. Without this flag, dry-run only.")
+@click.option(
+    "--progress/--no-progress",
+    default=True,
+    show_default=True,
+    help="Show a progress bar during processing.",
+)
 @click.pass_context
 def full_cmd(
     ctx: click.Context,
@@ -67,6 +73,7 @@ def full_cmd(
     retention_days: int,
     confirm_delete: bool,
     apply: bool,
+    progress: bool,
 ) -> None:
     client = SamsaraClient(rate_limits=ctx.obj.get("rate_limits"))
     # Dispatch directly to run_full. All action handling occurs inside run_full
@@ -81,6 +88,7 @@ def full_cmd(
         apply=apply,
         retention_days=retention_days,
         confirm_delete=confirm_delete,
+        progress=progress,
     )
 
 
@@ -97,6 +105,12 @@ def full_cmd(
 @click.option("--retention-days", default=30, show_default=True, type=int)
 @click.option("--confirm-delete", is_flag=True, help="Allow hard deletes after retention window.")
 @click.option("--apply", is_flag=True, help="Apply changes. Without this flag, dry-run only.")
+@click.option(
+    "--progress/--no-progress",
+    default=True,
+    show_default=True,
+    help="Show a progress bar during processing.",
+)
 @click.pass_context
 def daily_cmd(
     ctx: click.Context,
@@ -107,6 +121,7 @@ def daily_cmd(
     retention_days: int,
     confirm_delete: bool,
     apply: bool,
+    progress: bool,
 ) -> None:
     client = SamsaraClient(rate_limits=ctx.obj.get("rate_limits"))
     run_daily(
@@ -118,6 +133,7 @@ def daily_cmd(
         apply=apply,
         retention_days=retention_days,
         confirm_delete=confirm_delete,
+        progress=progress,
     )
 
 

--- a/src/encompass_to_samsara/sync_daily.py
+++ b/src/encompass_to_samsara/sync_daily.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import logging
 
+import requests
+
 from .matcher import index_addresses_by_external_id
 from .reporting import Action, ensure_out_dir, summarize, write_csv, write_jsonl
 from .safety import eligible_for_hard_delete, is_managed, is_warehouse, load_warehouses, now_utc_iso
-from .samsara_client import SamsaraClient
+from .samsara_client import ExternalIdConflictError, SamsaraClient
 from .state import load_state, save_state
 from .tags import CANDIDATE_DELETE_TAG, MANAGED_BY_TAG, build_tag_index, resolve_tag_id
 from .transform import (
@@ -28,15 +30,29 @@ def run_daily(
     apply: bool,
     retention_days: int,
     confirm_delete: bool,
+    progress: bool | None = None,
 ) -> None:
     ensure_out_dir(out_dir)
     actions: list[Action] = []
+    dup_rows: list[dict] = []
+    errors_rows: list[dict] = []
 
     state_path = f"{out_dir.rstrip('/')}/state.json"
     state = load_state(state_path)
 
     # Read inputs
     rows = read_encompass_csv(encompass_delta)
+    total = len(rows)
+    use_progress = bool(progress)
+    try:
+        from tqdm.auto import tqdm
+    except Exception:  # pragma: no cover - import guard
+        use_progress = False
+    iterable = (
+        tqdm(rows, total=total, unit="row", desc="Daily sync", dynamic_ncols=True, leave=False)
+        if use_progress
+        else rows
+    )
 
     # Fetch tags and addresses
     tags_index = build_tag_index(client)
@@ -49,7 +65,8 @@ def run_daily(
     # Warehouses
     wh_ids, wh_names = load_warehouses(warehouses_path)
 
-    for r in rows:
+    error_count = 0
+    for r in iterable:
         action = (r.action or "upsert").lower()
         if r.status.strip().upper() == "INACTIVE" and action != "delete":
             actions.append(
@@ -173,20 +190,68 @@ def run_daily(
                 continue
             diff = diff_address(existing, desired)
             if diff:
+                aid = str(existing.get("id"))
                 if apply:
-                    client.patch_address(str(existing.get("id")), diff)
-                actions.append(
-                    Action(
-                        at=now_utc_iso(),
-                        kind="update",
-                        address_id=str(existing.get("id")),
-                        encompass_id=r.encompass_id,
-                        reason="delta_update",
-                        payload=diff,
-                        diff=diff,
+                    try:
+                        client.patch_address(aid, diff)
+                    except ExternalIdConflictError:
+                        actions.append(
+                            Action(
+                                at=now_utc_iso(),
+                                kind="error",
+                                address_id=aid,
+                                encompass_id=r.encompass_id,
+                                reason="update_duplicate_external_id",
+                            )
+                        )
+                        dup_rows.append(
+                            {
+                                "type": "samsara_duplicate",
+                                "encompass_id": r.encompass_id,
+                                "count": 2,
+                            }
+                        )
+                        error_count += 1
+                    except requests.HTTPError as e:
+                        actions.append(
+                            Action(
+                                at=now_utc_iso(),
+                                kind="error",
+                                address_id=aid,
+                                encompass_id=r.encompass_id,
+                                reason="update_http_error",
+                            )
+                        )
+                        errors_rows.append(
+                            {"error": f"patch_failed: {e}", "row_name": r.name}
+                        )
+                        error_count += 1
+                    else:
+                        actions.append(
+                            Action(
+                                at=now_utc_iso(),
+                                kind="update",
+                                address_id=aid,
+                                encompass_id=r.encompass_id,
+                                reason="delta_update",
+                                payload=diff,
+                                diff=diff,
+                            )
+                        )
+                        state["fingerprints"][aid] = desired_fp
+                else:
+                    actions.append(
+                        Action(
+                            at=now_utc_iso(),
+                            kind="update",
+                            address_id=aid,
+                            encompass_id=r.encompass_id,
+                            reason="delta_update",
+                            payload=diff,
+                            diff=diff,
+                        )
                     )
-                )
-                state["fingerprints"][str(existing.get("id"))] = desired_fp
+                    state["fingerprints"][aid] = desired_fp
             else:
                 actions.append(
                     Action(
@@ -199,26 +264,65 @@ def run_daily(
                 )
         else:
             if apply:
-                created = client.create_address(desired)
-                aid = str(created.get("id") or "")
+                try:
+                    created = client.create_address(desired)
+                except requests.HTTPError as e:
+                    actions.append(
+                        Action(
+                            at=now_utc_iso(),
+                            kind="error",
+                            address_id=None,
+                            encompass_id=r.encompass_id,
+                            reason="create_http_error",
+                        )
+                    )
+                    errors_rows.append(
+                        {"error": f"create_failed: {e}", "row_name": r.name}
+                    )
+                    error_count += 1
+                    aid = None
+                else:
+                    aid = str(created.get("id") or "")
+                    actions.append(
+                        Action(
+                            at=now_utc_iso(),
+                            kind="create",
+                            address_id=aid,
+                            encompass_id=r.encompass_id,
+                            reason="delta_create",
+                            payload=desired,
+                        )
+                    )
+                    if aid:
+                        state["fingerprints"][aid] = desired_fp
             else:
                 aid = None
-            actions.append(
-                Action(
-                    at=now_utc_iso(),
-                    kind="create",
-                    address_id=aid,
-                    encompass_id=r.encompass_id,
-                    reason="delta_create",
-                    payload=desired,
+                actions.append(
+                    Action(
+                        at=now_utc_iso(),
+                        kind="create",
+                        address_id=aid,
+                        encompass_id=r.encompass_id,
+                        reason="delta_create",
+                        payload=desired,
+                    )
                 )
+                if aid:
+                    state["fingerprints"][aid] = desired_fp
+
+        if use_progress:
+            iterable.set_postfix_str(
+                f"creates={sum(1 for a in actions if a.kind=='create')} "
+                f"updates={sum(1 for a in actions if a.kind=='update')} errs={error_count}"
             )
-            if aid:
-                state["fingerprints"][aid] = desired_fp
 
     # Write outputs
     write_jsonl(f"{out_dir}/actions.jsonl", actions)
     summary = summarize(actions)
     report_rows = [{"metric": k, "value": v} for k, v in sorted(summary.items())]
     write_csv(f"{out_dir}/sync_report.csv", report_rows, ["metric", "value"])
+    if dup_rows:
+        write_csv(f"{out_dir}/duplicates.csv", dup_rows, ["type", "encompass_id", "count"])
+    if errors_rows:
+        write_csv(f"{out_dir}/errors.csv", errors_rows, ["error", "row_name"])
     save_state(state_path, state)

--- a/src/encompass_to_samsara/sync_full.py
+++ b/src/encompass_to_samsara/sync_full.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import requests
+
 from .matcher import find_by_name, index_addresses_by_external_id, probable_match
 from .reporting import Action, ensure_out_dir, summarize, write_csv, write_jsonl
 from .safety import eligible_for_hard_delete, is_managed, is_warehouse, load_warehouses, now_utc_iso
-from .samsara_client import SamsaraClient
+from .samsara_client import ExternalIdConflictError, SamsaraClient
 from .state import load_state, save_state
 from .tags import CANDIDATE_DELETE_TAG, MANAGED_BY_TAG, build_tag_index, resolve_tag_id
 from .transform import (
@@ -34,6 +36,7 @@ def run_full(
     apply: bool,
     retention_days: int,
     confirm_delete: bool,
+    progress: bool | None = None,
 ) -> None:
     ensure_out_dir(out_dir)
     actions: list[Action] = []
@@ -50,6 +53,17 @@ def run_full(
 
     # Read Encompass
     src_rows = read_encompass_csv(encompass_csv)
+    total = len(src_rows)
+    use_progress = bool(progress)
+    try:
+        from tqdm.auto import tqdm
+    except Exception:  # pragma: no cover - import guard
+        use_progress = False
+    iterable = (
+        tqdm(src_rows, total=total, unit="row", desc="Full sync", dynamic_ncols=True, leave=False)
+        if use_progress
+        else src_rows
+    )
     # Check duplicate encompass ids
     seen_eids: dict[str, int] = {}
     for r in src_rows:
@@ -77,8 +91,9 @@ def run_full(
     created_ids: list[str] = []
     updated_ids: list[str] = []
     unchanged_ids: list[str] = []
+    error_count = 0
 
-    for r in src_rows:
+    for r in iterable:
         if not r.encompass_id:
             continue
         if r.status.strip().upper() == "INACTIVE":
@@ -169,42 +184,120 @@ def run_full(
                     )
                 )
             else:
+                aid = str(existing.get("id"))
                 if apply:
-                    client.patch_address(str(existing.get("id")), diff)
-                updated_ids.append(str(existing.get("id")))
-                actions.append(
-                    Action(
-                        at=now_utc_iso(),
-                        kind="update",
-                        address_id=str(existing.get("id")),
-                        encompass_id=r.encompass_id,
-                        reason="update",
-                        payload=diff,
-                        diff=diff,
+                    try:
+                        client.patch_address(aid, diff)
+                    except ExternalIdConflictError:
+                        actions.append(
+                            Action(
+                                at=now_utc_iso(),
+                                kind="error",
+                                address_id=aid,
+                                encompass_id=r.encompass_id,
+                                reason="update_duplicate_external_id",
+                            )
+                        )
+                        dup_rows.append(
+                            {
+                                "type": "samsara_duplicate",
+                                "encompass_id": r.encompass_id,
+                                "count": 2,
+                            }
+                        )
+                        error_count += 1
+                    except requests.HTTPError as e:
+                        actions.append(
+                            Action(
+                                at=now_utc_iso(),
+                                kind="error",
+                                address_id=aid,
+                                encompass_id=r.encompass_id,
+                                reason="update_http_error",
+                            )
+                        )
+                        errors_rows.append(
+                            {"error": f"patch_failed: {e}", "row_name": r.name}
+                        )
+                        error_count += 1
+                    else:
+                        updated_ids.append(aid)
+                        actions.append(
+                            Action(
+                                at=now_utc_iso(),
+                                kind="update",
+                                address_id=aid,
+                                encompass_id=r.encompass_id,
+                                reason="update",
+                                payload=diff,
+                                diff=diff,
+                            )
+                        )
+                        state["fingerprints"][aid] = desired_fp
+                else:
+                    updated_ids.append(aid)
+                    actions.append(
+                        Action(
+                            at=now_utc_iso(),
+                            kind="update",
+                            address_id=aid,
+                            encompass_id=r.encompass_id,
+                            reason="update",
+                            payload=diff,
+                            diff=diff,
+                        )
                     )
-                )
-                # update state fingerprint
-                state["fingerprints"][str(existing.get("id"))] = desired_fp
+                    state["fingerprints"][aid] = desired_fp
         else:
             # Create
             if apply:
-                created = client.create_address(desired)
-                aid = str(created.get("id") or "")
+                try:
+                    created = client.create_address(desired)
+                except requests.HTTPError as e:
+                    actions.append(
+                        Action(
+                            at=now_utc_iso(),
+                            kind="error",
+                            address_id=None,
+                            encompass_id=r.encompass_id,
+                            reason="create_http_error",
+                        )
+                    )
+                    errors_rows.append(
+                        {"error": f"create_failed: {e}", "row_name": r.name}
+                    )
+                    error_count += 1
+                    aid = None
+                else:
+                    aid = str(created.get("id") or "")
+                    created_ids.append(aid)
+                    actions.append(
+                        Action(
+                            at=now_utc_iso(),
+                            kind="create",
+                            address_id=aid,
+                            encompass_id=r.encompass_id,
+                            reason="create",
+                            payload=desired,
+                        )
+                    )
+                    if aid:
+                        state["fingerprints"][aid] = desired_fp
             else:
                 aid = None
-            created_ids.append(aid or "(dry)")
-            actions.append(
-                Action(
-                    at=now_utc_iso(),
-                    kind="create",
-                    address_id=aid,
-                    encompass_id=r.encompass_id,
-                    reason="create",
-                    payload=desired,
+                created_ids.append(aid or "(dry)")
+                actions.append(
+                    Action(
+                        at=now_utc_iso(),
+                        kind="create",
+                        address_id=aid,
+                        encompass_id=r.encompass_id,
+                        reason="create",
+                        payload=desired,
+                    )
                 )
-            )
-            if aid:
-                state["fingerprints"][aid] = desired_fp
+                if aid:
+                    state["fingerprints"][aid] = desired_fp
 
         # prepare dry-run diff row
         dry_rows.append(
@@ -214,6 +307,11 @@ def run_full(
                 "action": actions[-1].kind if actions else "skip",
             }
         )
+        if use_progress:
+            iterable.set_postfix_str(
+                f"created={len(created_ids)} updated={len(updated_ids)} "
+                f"unchanged={len(unchanged_ids)} errs={error_count}"
+            )
 
     # Orphan detection: managed samsara addresses not in src_eids
     for addr in samsara_addrs:


### PR DESCRIPTION
## Summary
- introduce `ExternalIdConflictError` and handle duplicate external IDs
- log per-row errors and continue processing during full and daily syncs
- add optional tqdm progress bars for full and daily runs

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b853af72548328a688bff092008378