### PR TITLE
Sanitize delete-candidate external IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,4 +187,4 @@ Codex automatically merges agent guidance from the files in `codex/` and your
 > **Note**: The tag **CandidateDelete** is used to quarantine orphans.
 > Ensure a Tag named exactly `CandidateDelete` exists in Samsara (the CLI cannot create tags
 > – only List Tags is allowed by requirements). If missing, the tool falls back to setting
-> `externalIds.ENCOMPASS_DELETE_CANDIDATE="<timestamp>-<addressId>"` and logs a warning.
+> `externalIds.ENCOMPASS_DELETE_CANDIDATE="<timestamp><addressId>"` and logs a warning.

--- a/src/encompass_to_samsara.egg-info/PKG-INFO
+++ b/src/encompass_to_samsara.egg-info/PKG-INFO
@@ -12,6 +12,7 @@ Requires-Dist: requests>=2.32.3
 Requires-Dist: python-dotenv>=1.0.1
 Requires-Dist: PyYAML>=6.0.2
 Requires-Dist: pytz>=2024.1
+Requires-Dist: tqdm>=4.66
 Provides-Extra: dev
 Requires-Dist: pytest>=8.1.1; extra == "dev"
 Requires-Dist: responses>=0.25.3; extra == "dev"
@@ -75,6 +76,30 @@ sync-e2s daily   --encompass-delta data/encompass_delta.csv   --warehouses data/
   - Orphans are tagged **CandidateDelete** (quarantine).
   - Hard delete only when **both** `--confirm-delete` and retention window elapsed.
 
+### Rate limiting configuration
+
+Use `--api-rate-config <file>` to supply a JSON file that tunes client-side throttling.
+The file may specify a global `min_interval` (seconds between any two requests) and
+per-endpoint limits in requests per second keyed by "METHOD /path".
+
+Example `rate_limits.json`:
+
+```json
+{
+  "min_interval": 0.2,
+  "GET /addresses": 3,
+  "POST /addresses": 1
+}
+```
+
+Run the CLI with the config:
+
+```bash
+sync-e2s --api-rate-config rate_limits.json full --encompass-csv data/encompass_full.csv --warehouses data/warehouses.csv --out-dir output
+```
+
+Delays introduced by these limits are logged at DEBUG with the HTTP method and path.
+
 ### Inputs
 
 1. **Full Encompass CSV** with columns:
@@ -136,6 +161,7 @@ payload = {
   after retention window.
 - Never touch entries in `warehouses.csv` (denylist of Samsara IDs/names).
 - Retries/backoff on 429/5xx with exponential backoff + jitter; UTC timestamps; logs retries.
+- Configurable per-endpoint rate limiting via `--api-rate-config`; delays are logged at DEBUG with the HTTP method and path.
 
 ### Reports (written to `./output/`)
 
@@ -182,4 +208,4 @@ Codex automatically merges agent guidance from the files in `codex/` and your
 > **Note**: The tag **CandidateDelete** is used to quarantine orphans.
 > Ensure a Tag named exactly `CandidateDelete` exists in Samsara (the CLI cannot create tags
 > – only List Tags is allowed by requirements). If missing, the tool falls back to setting
-> `externalIds.ENCOMPASS_DELETE_CANDIDATE="<timestamp>-<addressId>"` and logs a warning.
+> `externalIds.ENCOMPASS_DELETE_CANDIDATE="<timestamp><addressId>"` and logs a warning.

--- a/src/encompass_to_samsara/sync_daily.py
+++ b/src/encompass_to_samsara/sync_daily.py
@@ -14,6 +14,7 @@ from .transform import (
     clean_external_ids,
     diff_address,
     read_encompass_csv,
+    sanitize_external_id_value,
     to_address_payload,
 )
 
@@ -119,7 +120,8 @@ def run_daily(
                 else:
                     ext = clean_external_ids(existing.get("externalIds") or {})
                     if "encompass_delete_candidate" not in ext:
-                        marker = f"{now_utc_iso()[:19].replace(':', '').replace('-', '')}-{aid}"
+                        marker_raw = f"{now_utc_iso()[:19].replace(':', '').replace('-', '')}-{aid}"
+                        marker = sanitize_external_id_value(marker_raw)
                         patch = {"externalIds": ext | {"ENCOMPASS_DELETE_CANDIDATE": marker}}
                         if apply:
                             client.patch_address(aid, patch)

--- a/src/encompass_to_samsara/sync_full.py
+++ b/src/encompass_to_samsara/sync_full.py
@@ -15,6 +15,7 @@ from .transform import (
     clean_external_ids,
     diff_address,
     read_encompass_csv,
+    sanitize_external_id_value,
     to_address_payload,
 )
 
@@ -357,7 +358,8 @@ def run_full(
             # fallback to externalIds marker
             ext2 = clean_external_ids(addr.get("externalIds") or {})
             if "encompass_delete_candidate" not in ext2:
-                marker = f"{now_utc_iso()[:19].replace(':', '').replace('-', '')}-{aid}"
+                marker_raw = f"{now_utc_iso()[:19].replace(':', '').replace('-', '')}-{aid}"
+                marker = sanitize_external_id_value(marker_raw)
                 patch = {"externalIds": ext2 | {"ENCOMPASS_DELETE_CANDIDATE": marker}}
                 if apply:
                     client.patch_address(aid, patch)

--- a/src/encompass_to_samsara/transform.py
+++ b/src/encompass_to_samsara/transform.py
@@ -11,7 +11,8 @@ LOG = logging.getLogger(__name__)
 
 RE_SPACES = re.compile(r"\s+")
 RE_PUNCT = re.compile(r"[^\w\s]")
-RE_EXT_ID_ALLOWED = re.compile(r"[^A-Za-z0-9:_-]")
+RE_EXT_ID_KEY_ALLOWED = re.compile(r"[^A-Za-z0-9:_-]")
+RE_EXT_ID_VALUE_ALLOWED = re.compile(r"[^A-Za-z0-9]")
 MAX_EXT_ID_LEN = 32
 
 REQUIRED_COLUMNS = [
@@ -127,7 +128,7 @@ def sanitize_external_id_value(v: Any) -> str | None:
     s = str(v).strip()
     if not s:
         return None
-    cleaned = RE_EXT_ID_ALLOWED.sub("", s)
+    cleaned = RE_EXT_ID_VALUE_ALLOWED.sub("", s)
     if cleaned != s:
         if cleaned:
             LOG.warning(
@@ -156,7 +157,7 @@ def sanitize_external_id_key(k: Any) -> str | None:
     s = str(k).strip()
     if not s:
         return None
-    cleaned = RE_EXT_ID_ALLOWED.sub("", s)
+    cleaned = RE_EXT_ID_KEY_ALLOWED.sub("", s)
     if cleaned != s:
         if cleaned:
             LOG.warning(

--- a/tests/test_daily.py
+++ b/tests/test_daily.py
@@ -238,7 +238,7 @@ def test_delete_marker_unique_and_by_address(tmp_path, token_env, monkeypatch):
                 body = body.decode()
             payload = json.loads(body)
             val = payload["externalIds"]["ENCOMPASS_DELETE_CANDIDATE"]
-            assert val == f"20240829T123456-{aid}"
+            assert val == f"20240829T123456{aid}"
             markers.append(val)
         assert markers[0] != markers[1]
 
@@ -274,7 +274,7 @@ def test_no_patch_when_marker_exists(tmp_path, token_env, monkeypatch):
             "formattedAddress": "123 A St",
             "externalIds": {
                 "EncompassId": "C1",
-                "ENCOMPASS_DELETE_CANDIDATE": "20240829T123456-300",
+                "ENCOMPASS_DELETE_CANDIDATE": "20240829T123456300",
             },
             "tagIds": ["1"],
         }

--- a/tests/test_samsara_client.py
+++ b/tests/test_samsara_client.py
@@ -99,9 +99,10 @@ def test_create_address_with_sanitized_external_ids(monkeypatch, client):
 
     assert result == {"id": "123"}
     sent = mock_req.call_args[1]["json_body"]
-    allowed = re.compile(r"^[A-Za-z0-9_.:-]+$")
-    assert all(allowed.match(k) for k in sent["externalIds"])
-    assert all(allowed.match(v) for v in sent["externalIds"].values())
+    allowed_keys = re.compile(r"^[A-Za-z0-9_.:-]+$")
+    allowed_vals = re.compile(r"^[A-Za-z0-9]+$")
+    assert all(allowed_keys.match(k) for k in sent["externalIds"])
+    assert all(allowed_vals.match(v) for v in sent["externalIds"].values())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -116,9 +116,9 @@ def test_sanitize_external_id_value_strips(caplog):
     assert any("invalid" in r.message for r in caplog.records)
 
 
-def test_sanitize_external_id_value_allows_underscore():
+def test_sanitize_external_id_value_strips_non_alnum():
     val = sanitize_external_id_value("foo_bar-123")
-    assert val == "foo_bar-123"
+    assert val == "foobar123"
 
 
 def test_clean_external_ids_sanitizes_and_drops(caplog):


### PR DESCRIPTION
## Summary
- ensure external ID values are strictly alphanumeric by introducing separate regex for keys and values
- sanitize deletion marker external IDs before patching addresses
- document updated delete candidate marker format

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b861f133308328b01a51ed9fb409fb