### PR TITLE
Add script for deleting Samsara addresses from CSV/Excel lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ python -m encompass_to_samsara.scripts.export_addresses
 
 The script writes all existing Samsara addresses to `addresses.json`.
 
+### Delete Samsara addresses
+
+Provide a CSV or Excel file with an `ID` column listing the address IDs to remove.
+
+```bash
+export SAMSARA_BEARER_TOKEN=your_token
+python -m encompass_to_samsara.scripts.delete_addresses path/to/ids.csv
+```
+
+The script iterates through the IDs and calls the Samsara Delete Address endpoint for
+each.
+
 ### CLI
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "PyYAML>=6.0.2",
   "pytz>=2024.1",
   "tqdm>=4.66",
+  "openpyxl>=3.1.2",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-dotenv>=1.0.1
 PyYAML>=6.0.2
 pytz>=2024.1
 tqdm>=4.66
+openpyxl>=3.1.2
 pytest>=8.1.1
 responses>=0.25.3
 ruff>=0.5.7

--- a/src/encompass_to_samsara/scripts/delete_addresses.py
+++ b/src/encompass_to_samsara/scripts/delete_addresses.py
@@ -1,0 +1,81 @@
+"""Delete a batch of Samsara addresses by ID.
+
+The script accepts a CSV or Excel file containing a column named ``ID``. Each value in
+that column is passed to :meth:`SamsaraClient.delete_address`.
+
+Example usage::
+
+    export SAMSARA_BEARER_TOKEN=your_token
+    python -m encompass_to_samsara.scripts.delete_addresses ids.csv
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+from ..samsara_client import SamsaraClient
+
+
+def _load_ids(path: Path) -> list[str]:
+    """Return address IDs from ``path``.
+
+    ``path`` may point to a ``.csv`` or ``.xlsx`` file. Files must contain a column
+    header ``ID``.
+    """
+
+    if path.suffix.lower() == ".csv":
+        with path.open("r", encoding="utf-8", newline="") as f:
+            reader = csv.DictReader(f)
+            if reader.fieldnames is None or "ID" not in reader.fieldnames:
+                msg = "CSV must contain an 'ID' column"
+                raise ValueError(msg)
+            return [row["ID"].strip() for row in reader if row.get("ID")]
+
+    if path.suffix.lower() == ".xlsx":
+        wb = load_workbook(filename=path, read_only=True)
+        ws = wb.active
+        header_row = next(ws.iter_rows(min_row=1, max_row=1))
+        headers = [c.value for c in header_row]
+        try:
+            idx = headers.index("ID")
+        except ValueError as exc:  # pragma: no cover - path exercised in tests
+            raise ValueError("Excel file must contain an 'ID' column") from exc
+        ids: list[str] = []
+        for row in ws.iter_rows(min_row=2):
+            val = row[idx].value
+            if val is not None and str(val).strip():
+                ids.append(str(val).strip())
+        return ids
+
+    msg = "Unsupported file type; use .csv or .xlsx"
+    raise ValueError(msg)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Delete Samsara addresses specified in a CSV or Excel file"
+    )
+    parser.add_argument("input", help="Path to CSV or Excel file with an 'ID' column")
+    args = parser.parse_args(argv)
+
+    ids = _load_ids(Path(args.input))
+    client = SamsaraClient(api_token=os.environ["SAMSARA_BEARER_TOKEN"])
+
+    for addr_id in ids:
+        try:
+            client.delete_address(addr_id)
+            print(f"Deleted {addr_id}")
+        except Exception as exc:  # pragma: no cover - network errors
+            print(f"Failed to delete {addr_id}: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_delete_script.py
+++ b/tests/test_delete_script.py
@@ -1,0 +1,53 @@
+import csv
+from pathlib import Path
+
+from openpyxl import Workbook
+
+from encompass_to_samsara.samsara_client import SamsaraClient
+from encompass_to_samsara.scripts import delete_addresses
+
+
+def _write_csv(path: Path, ids: list[str]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["ID"])
+        w.writeheader()
+        for i in ids:
+            w.writerow({"ID": i})
+
+
+def _write_xlsx(path: Path, ids: list[str]) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["ID"])
+    for i in ids:
+        ws.append([i])
+    wb.save(path)
+
+
+def test_delete_from_csv(tmp_path, monkeypatch):
+    ids = ["10", "20"]
+    file_path = tmp_path / "ids.csv"
+    _write_csv(file_path, ids)
+
+    deleted: list[str] = []
+    monkeypatch.setenv("SAMSARA_BEARER_TOKEN", "token")
+    monkeypatch.setattr(SamsaraClient, "delete_address", lambda self, aid: deleted.append(aid))
+
+    delete_addresses.main([str(file_path)])
+
+    assert deleted == ids
+
+
+def test_delete_from_excel(tmp_path, monkeypatch):
+    ids = ["30", "40"]
+    file_path = tmp_path / "ids.xlsx"
+    _write_xlsx(file_path, ids)
+
+    deleted: list[str] = []
+    monkeypatch.setenv("SAMSARA_BEARER_TOKEN", "token")
+    monkeypatch.setattr(SamsaraClient, "delete_address", lambda self, aid: deleted.append(aid))
+
+    delete_addresses.main([str(file_path)])
+
+    assert deleted == ids
+


### PR DESCRIPTION
## Summary
- add `delete_addresses` helper to remove IDs read from CSV or Excel
- document new deletion script and require `openpyxl`
- include tests verifying CSV and Excel deletion flows

## Testing
- `ruff check src/encompass_to_samsara/scripts/delete_addresses.py tests/test_delete_script.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b876ebfa788328b12b04e7bb92b155