### PR TITLE
Update Ruff configuration and lint fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ full-apply: ; python -m encompass_to_samsara.cli full  --encompass-csv data/enco
 daily-dry:  ; python -m encompass_to_samsara.cli daily --encompass-delta data/encompass_delta.csv --warehouses data/warehouses.csv --out-dir output
 daily-apply:; python -m encompass_to_samsara.cli daily --encompass-delta data/encompass_delta.csv --warehouses data/warehouses.csv --out-dir output --apply
 test:       ; pytest -q
-lint:       ; ruff check .
-fmt:        ; ruff format .
+lint:       ; ruff check --config ruff.toml .
+fmt:        ; ruff format --config ruff.toml .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,7 @@ sync-e2s = "encompass_to_samsara.cli:main"
 [tool.ruff]
 line-length = 100
 target-version = "py311"
-select = ["E","F","I","UP","B"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
 fix = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,6 @@
+line-length = 100
+target-version = "py311"
+fix = true
+
+[lint]
+select = ["E", "F", "I", "UP", "B"]

--- a/src/encompass_to_samsara/cli.py
+++ b/src/encompass_to_samsara/cli.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
-import json
 
 import click
 from dotenv import load_dotenv

--- a/src/encompass_to_samsara/transform.py
+++ b/src/encompass_to_samsara/transform.py
@@ -4,8 +4,8 @@ import csv
 import hashlib
 import logging
 import re
-from datetime import datetime
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 LOG = logging.getLogger(__name__)
@@ -364,7 +364,10 @@ def diff_address(existing: dict, desired: dict) -> dict:
     # geofence (compare circle lat/lon and radius)
     e_geo = normalize_geofence(existing.get("geofence")) or {}
     d_geo = normalize_geofence(desired.get("geofence")) or {}
-    skip_geofence = bool((existing.get("geofence") or {}).get("polygon")) or _has_updated_geofence_tag(existing)
+    skip_geofence = (
+        bool((existing.get("geofence") or {}).get("polygon"))
+        or _has_updated_geofence_tag(existing)
+    )
     if not skip_geofence:
         if bool(d_geo) != bool(e_geo):
             patch["geofence"] = d_geo or None

--- a/tests/test_actions_geofence.py
+++ b/tests/test_actions_geofence.py
@@ -28,7 +28,9 @@ def write_csv(path, rows):
         (run_daily, "encompass_delta"),
     ],
 )
-def test_actions_jsonl_geofence_always_circle(tmp_path, token_env, base_responses, sync_func, src_arg):
+def test_actions_jsonl_geofence_always_circle(
+    tmp_path, token_env, base_responses, sync_func, src_arg
+):
     row = {
         "Customer ID": "C1",
         "Customer Name": "Foo",

--- a/tests/test_cli_rate_config.py
+++ b/tests/test_cli_rate_config.py
@@ -1,5 +1,7 @@
 import json
+
 from click.testing import CliRunner
+
 from encompass_to_samsara.cli import cli
 
 

--- a/tests/test_delete_flow.py
+++ b/tests/test_delete_flow.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 from encompass_to_samsara.sync_daily import run_daily
@@ -38,7 +37,18 @@ def write_csv(path: Path, rows):
 
 def test_delete_direct_when_retention_zero(tmp_path, monkeypatch):
     delta_rows = [
-        {"Customer ID": "C1", "Customer Name": "Foo", "Account Status": "Active", "Latitude": "30", "Longitude": "-97", "Report Address": "123", "Location": "Austin", "Company": "JECO", "Customer Type": "Retail", "Action": "delete"}
+        {
+            "Customer ID": "C1",
+            "Customer Name": "Foo",
+            "Account Status": "Active",
+            "Latitude": "30",
+            "Longitude": "-97",
+            "Report Address": "123",
+            "Location": "Austin",
+            "Company": "JECO",
+            "Customer Type": "Retail",
+            "Action": "delete",
+        }
     ]
     d_csv = tmp_path / "delta.csv"
     write_csv(d_csv, delta_rows)
@@ -66,7 +76,18 @@ def test_delete_direct_when_retention_zero(tmp_path, monkeypatch):
 
 def test_mark_delete_with_retention(tmp_path, monkeypatch):
     delta_rows = [
-        {"Customer ID": "C1", "Customer Name": "Foo", "Account Status": "Active", "Latitude": "30", "Longitude": "-97", "Report Address": "123", "Location": "Austin", "Company": "JECO", "Customer Type": "Retail", "Action": "delete"}
+        {
+            "Customer ID": "C1",
+            "Customer Name": "Foo",
+            "Account Status": "Active",
+            "Latitude": "30",
+            "Longitude": "-97",
+            "Report Address": "123",
+            "Location": "Austin",
+            "Company": "JECO",
+            "Customer Type": "Retail",
+            "Action": "delete",
+        }
     ]
     d_csv = tmp_path / "delta.csv"
     write_csv(d_csv, delta_rows)

--- a/tests/test_sync_full.py
+++ b/tests/test_sync_full.py
@@ -347,7 +347,10 @@ def test_full_continues_after_patch_error(tmp_path, token_env, base_responses):
 
     with open(out_dir / "actions.jsonl", encoding="utf-8") as f:
         acts = [json.loads(line) for line in f]
-    assert any(a["kind"] == "error" and a.get("reason") == "update_duplicate_external_id" for a in acts)
+    assert any(
+        a["kind"] == "error" and a.get("reason") == "update_duplicate_external_id"
+        for a in acts
+    )
     assert any(a["kind"] == "create" for a in acts)
     with open(out_dir / "duplicates.csv", encoding="utf-8") as f:
         dup_lines = f.read()

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,17 +1,17 @@
 import re
 
+from encompass_to_samsara.tags import build_tag_index
 from encompass_to_samsara.transform import (
     SourceRow,
+    clean_external_ids,
     compute_fingerprint,
     diff_address,
-    clean_external_ids,
     normalize,
+    normalize_geofence,
     sanitize_external_id_value,
     to_address_payload,
     validate_lat_lon,
-    normalize_geofence,
 )
-from encompass_to_samsara.tags import build_tag_index
 
 
 def test_normalize_and_fingerprint_stability():


### PR DESCRIPTION
## Summary
- update the Ruff configuration in `pyproject.toml` to use the new `lint` table and enable fixing
- add a repo-level `ruff.toml` and point the Makefile lint/format targets at it for compatibility
- adjust import ordering and wrap long lines so the codebase satisfies the updated Ruff rules

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68c85b9468f48328af7feb4528725592