### PR TITLE
Add Samsara driver helpers and tests

### DIFF
--- a/rate_limits.json
+++ b/rate_limits.json
@@ -1,0 +1,12 @@
+{
+  "min_interval": 0.2,
+  "GET /addresses": 3,
+  "POST /addresses": 1,
+  "PATCH /addresses/{id}": 1,
+  "DELETE /addresses/{id}": 1,
+  "GET /tags": 3,
+  "GET /fleet/drivers": 3,
+  "GET /fleet/drivers/{id}": 3,
+  "POST /fleet/drivers": 1,
+  "PATCH /fleet/drivers/{id}": 1
+}


### PR DESCRIPTION
## Summary
- add driver management helpers to the Samsara client including pagination support and response-shape handling
- provide convenience helpers for retrieving all drivers and updating individual drivers
- extend the rate limit configuration and unit tests to cover the new driver endpoints

## Testing
- make lint
- PYTHONPATH=src make test

------
https://chatgpt.com/codex/tasks/task_e_68c8628b3ba883288a389e8fa394457d