### PR TITLE
Add driver username generation utility

### DIFF
--- a/src/encompass_to_samsara/drivers_utils.py
+++ b/src/encompass_to_samsara/drivers_utils.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+_MAX_USERNAME_LENGTH = 189
+_ALLOWED_CHARACTERS_RE = re.compile(r"[^a-z0-9]")
+
+
+def _slugify(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_value = normalized.encode("ascii", "ignore").decode("ascii")
+    return _ALLOWED_CHARACTERS_RE.sub("", ascii_value.lower())
+
+
+def generate_username(first: str, last: str, taken: set[str]) -> str:
+    """Generate a unique username for a driver.
+
+    The username is formed from the first initial and last name, stripped to
+    lowercase ASCII letters and digits. When collisions occur, a numeric suffix
+    is added while ensuring the resulting username does not exceed the maximum
+    allowed length.
+    """
+
+    first_slug = _slugify(first)
+    last_slug = _slugify(last)
+
+    base = f"{first_slug[:1]}{last_slug}"
+
+    suffix = 1
+    while True:
+        suffix_str = f"-{suffix}"
+        max_base_length = _MAX_USERNAME_LENGTH - len(suffix_str)
+        truncated_base = base[:max_base_length] if max_base_length > 0 else ""
+        candidate = f"{truncated_base}{suffix_str}"
+        if candidate not in taken:
+            return candidate
+        suffix += 1

--- a/tests/test_drivers_utils.py
+++ b/tests/test_drivers_utils.py
@@ -1,0 +1,24 @@
+from encompass_to_samsara.drivers_utils import generate_username
+
+
+def test_generate_username_slugifies_input() -> None:
+    username = generate_username("Élodie", "O'Connor-Sánchez 3rd", set())
+    assert username == "eoconnorsanchez3rd-1"
+
+
+def test_generate_username_increments_until_available() -> None:
+    taken = {"jdoe-1", "jdoe-2"}
+    assert generate_username("John", "Doe", taken) == "jdoe-3"
+
+
+def test_generate_username_truncates_before_suffix() -> None:
+    first = "A"
+    last = "B" * 300
+
+    base_for_two_digit_suffix = "a" + "b" * 186
+    taken = {f"{base_for_two_digit_suffix}-{i}" for i in range(1, 10)}
+
+    username = generate_username(first, last, taken)
+
+    assert username == "a" + "b" * 185 + "-10"
+    assert len(username) == 189


### PR DESCRIPTION
## Summary
- add a utility to build driver usernames with slugging, truncation, and suffix handling
- add tests covering slug normalization, collision handling, and maximum length enforcement

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68c8643cf5708328b412619c9f32dd53