### PR TITLE
Add Paycom driver fingerprint sync helpers

### DIFF
--- a/src/encompass_to_samsara/driver_sync.py
+++ b/src/encompass_to_samsara/driver_sync.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+from typing import Any
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+_CONTACT_FIELDS: dict[str, dict[str, tuple[str, ...] | str]] = {
+    "Work_Email": {
+        "patch_key": "email",
+        "lookup_keys": ("Work_Email", "workEmail", "email"),
+    },
+    "Primary_Phone": {
+        "patch_key": "primaryPhone",
+        "lookup_keys": ("Primary_Phone", "primaryPhone", "primary_phone"),
+    },
+    "Secondary_Phone": {
+        "patch_key": "secondaryPhone",
+        "lookup_keys": ("Secondary_Phone", "secondaryPhone", "secondary_phone"),
+    },
+}
+
+_FINGERPRINT_IGNORED_KEYS = frozenset(_CONTACT_FIELDS)
+
+
+def _normalize_text(value: Any) -> str:
+    if value is None:
+        return ""
+    s = str(value).strip()
+    if not s:
+        return ""
+    return _WHITESPACE_RE.sub(" ", s)
+
+
+def _normalize_contact(value: Any) -> str | None:
+    normalized = _normalize_text(value)
+    return normalized or None
+
+
+def compute_paycom_fingerprint(row: Mapping[str, Any]) -> str:
+    """Return a stable fingerprint for a Paycom driver row."""
+
+    parts: list[str] = []
+    for key in sorted(row.keys()):
+        if key in _FINGERPRINT_IGNORED_KEYS:
+            continue
+        parts.append(f"{key}={_normalize_text(row.get(key))}")
+    payload = "\u001f".join(parts).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _get_from_mapping(mapping: Mapping[str, Any] | None, keys: tuple[str, ...]) -> Any:
+    if not isinstance(mapping, Mapping):
+        return None
+    for key in keys:
+        if key in mapping:
+            return mapping.get(key)
+    return None
+
+
+def _get_driver_contact(driver: Mapping[str, Any], row_key: str) -> str | None:
+    config = _CONTACT_FIELDS[row_key]
+    lookup_keys = config["lookup_keys"]
+    value = _get_from_mapping(driver, lookup_keys)
+    if value is not None:
+        return _normalize_contact(value)
+    metadata = driver.get("metadata") if isinstance(driver, Mapping) else None
+    value = _get_from_mapping(metadata, lookup_keys)
+    if value is not None:
+        return _normalize_contact(value)
+    return None
+
+
+def build_driver_patch(row: Mapping[str, Any], samsara_driver: Mapping[str, Any]) -> dict[str, Any]:
+    """Build a PATCH payload for a Samsara driver based on a Paycom row.
+
+    The payload updates ``externalIds.paycom_fingerprint`` whenever the
+    newly computed fingerprint differs from the value stored on the Samsara
+    driver. It also updates Work Email and phone contact information if
+    those values differ between the Paycom row and the Samsara record.
+
+    Parameters
+    ----------
+    row:
+        Paycom CSV row represented as a mapping.
+    samsara_driver:
+        Existing Samsara driver record.
+
+    Returns
+    -------
+    dict[str, Any]
+        PATCH payload. Empty when no updates are required.
+    """
+
+    patch: dict[str, Any] = {}
+
+    new_fp = compute_paycom_fingerprint(row)
+    ext_ids = samsara_driver.get("externalIds") if isinstance(samsara_driver, Mapping) else None
+    existing_fp = None
+    if isinstance(ext_ids, Mapping):
+        existing_fp = ext_ids.get("paycom_fingerprint")
+    if existing_fp != new_fp:
+        ext_patch = dict(ext_ids) if isinstance(ext_ids, Mapping) else {}
+        ext_patch["paycom_fingerprint"] = new_fp
+        patch["externalIds"] = ext_patch
+
+    metadata = samsara_driver.get("metadata") if isinstance(samsara_driver, Mapping) else None
+    metadata_base = dict(metadata) if isinstance(metadata, Mapping) else {}
+    metadata_patch: dict[str, Any] | None = None
+
+    for row_key, config in _CONTACT_FIELDS.items():
+        new_val = _normalize_contact(row.get(row_key))
+        existing_val = _get_driver_contact(samsara_driver, row_key)
+        if new_val != existing_val:
+            patch[config["patch_key"]] = new_val
+
+        metadata_existing = _normalize_contact(metadata_base.get(row_key))
+        if new_val != metadata_existing:
+            if metadata_patch is None:
+                metadata_patch = dict(metadata_base)
+            if new_val is None:
+                metadata_patch.pop(row_key, None)
+            else:
+                metadata_patch[row_key] = new_val
+
+    if metadata_patch is not None:
+        patch["metadata"] = metadata_patch
+
+    return patch

--- a/tests/test_driver_sync.py
+++ b/tests/test_driver_sync.py
@@ -1,0 +1,124 @@
+from encompass_to_samsara.driver_sync import build_driver_patch, compute_paycom_fingerprint
+
+
+def test_compute_paycom_fingerprint_ignores_contact_fields():
+    base_row = {
+        "Employee_ID": "123",
+        "First_Name": "Ada",
+        "Last_Name": "Lovelace",
+        "Status": "Active",
+        "Department": "Engineering",
+        "Work_Email": "ada@example.com",
+        "Primary_Phone": "555-000-1111",
+    }
+
+    fingerprint1 = compute_paycom_fingerprint(base_row)
+
+    modified_contacts = {
+        **base_row,
+        "Work_Email": "ada@new.example.com",
+        "Primary_Phone": "555-123-4567",
+        "Secondary_Phone": "555-765-4321",
+    }
+
+    fingerprint2 = compute_paycom_fingerprint(modified_contacts)
+
+    assert fingerprint1 == fingerprint2
+
+    changed_core = {**base_row, "Status": "Inactive"}
+    fingerprint3 = compute_paycom_fingerprint(changed_core)
+
+    assert fingerprint3 != fingerprint1
+
+
+def test_build_driver_patch_updates_external_id_and_contacts():
+    row = {
+        "Employee_ID": "123",
+        "First_Name": "Ada",
+        "Last_Name": "Lovelace",
+        "Status": "Active",
+        "Department": "Engineering",
+        "Work_Email": "ada@new.example.com",
+        "Primary_Phone": "555-123-4567",
+        "Secondary_Phone": "555-765-4321",
+    }
+
+    samsara_driver = {
+        "externalIds": {"paycom_fingerprint": "old"},
+        "metadata": {
+            "Work_Email": "ada@example.com",
+            "Primary_Phone": "555-000-0000",
+            "other": "keep",
+        },
+        "email": "ada@example.com",
+        "primaryPhone": "555-000-0000",
+    }
+
+    patch = build_driver_patch(row, samsara_driver)
+
+    expected_fp = compute_paycom_fingerprint(row)
+    assert patch["externalIds"]["paycom_fingerprint"] == expected_fp
+    assert patch["email"] == "ada@new.example.com"
+    assert patch["primaryPhone"] == "555-123-4567"
+    assert patch["secondaryPhone"] == "555-765-4321"
+    assert patch["metadata"]["Work_Email"] == "ada@new.example.com"
+    assert patch["metadata"]["other"] == "keep"
+
+
+def test_build_driver_patch_contact_only_change():
+    row = {
+        "Employee_ID": "123",
+        "First_Name": "Ada",
+        "Last_Name": "Lovelace",
+        "Status": "Active",
+        "Department": "Engineering",
+        "Work_Email": "ada@new.example.com",
+        "Primary_Phone": "555-123-4567",
+    }
+
+    fingerprint = compute_paycom_fingerprint(row)
+
+    samsara_driver = {
+        "externalIds": {"paycom_fingerprint": fingerprint},
+        "metadata": {
+            "Work_Email": "ada@example.com",
+            "Primary_Phone": "555-000-0000",
+        },
+        "email": "ada@example.com",
+        "primaryPhone": "555-000-0000",
+    }
+
+    patch = build_driver_patch(row, samsara_driver)
+
+    assert "externalIds" not in patch
+    assert patch["email"] == "ada@new.example.com"
+    assert patch["primaryPhone"] == "555-123-4567"
+    assert patch["metadata"]["Work_Email"] == "ada@new.example.com"
+
+
+def test_build_driver_patch_no_changes_returns_empty():
+    row = {
+        "Employee_ID": "123",
+        "First_Name": "Ada",
+        "Last_Name": "Lovelace",
+        "Status": "Active",
+        "Department": "Engineering",
+        "Work_Email": "ada@example.com",
+        "Primary_Phone": "555-000-0000",
+    }
+
+    fingerprint = compute_paycom_fingerprint(row)
+
+    samsara_driver = {
+        "externalIds": {"paycom_fingerprint": fingerprint},
+        "metadata": {
+            "Work_Email": "ada@example.com",
+            "Primary_Phone": "555-000-0000",
+        },
+        "email": "ada@example.com",
+        "primaryPhone": "555-000-0000",
+    }
+
+    patch = build_driver_patch(row, samsara_driver)
+
+    assert patch == {}


### PR DESCRIPTION
## Summary
- add a driver_sync helper that computes Paycom fingerprints and builds PATCH payloads for Samsara drivers
- ensure contact metadata and external IDs are updated when fingerprints or contact fields differ
- cover the driver sync behavior with unit tests for fingerprints and patch construction

## Testing
- pytest -q
- ruff check src/encompass_to_samsara/driver_sync.py tests/test_driver_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68c87fae18108328b0ba25455aa08868