### PR TITLE
Document Paycom driver external IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,122 @@ payload = {
 }
 ```
 
+### Paycom driver external IDs
+
+The Paycom → Samsara driver sync stores two additional external identifiers on
+every driver record so we can look up existing employees and detect field-level
+changes without diffing the entire payload:
+
+- `employeeCode` – the unique Paycom employee code after being sanitized with
+  the same rules used for other `externalIds` values (invalid characters are
+  dropped and the value is truncated to 32 characters).
+- `paycom_fingerprint` – a 64-character SHA-256 hex digest computed from the
+  normalized Paycom row. This is the idempotency key that keeps repeated runs
+  from issuing redundant PATCH requests when nothing material has changed.
+
+#### Field coverage and normalization
+
+The fingerprint covers the core identity, contact, compliance, and routing
+fields we receive from Paycom. Each field is normalized before being added to
+the fingerprint payload so cosmetic differences (extra spaces, punctuation, or
+mixed casing) do not trigger unnecessary updates.
+
+| Paycom column                 | Normalization rule                                                                              |
+| ----------------------------- | ----------------------------------------------------------------------------------------------- |
+| `First Name`, `Preferred Name`, `Last Name` | `normalize(...)` – lower-case, trim, strip punctuation, collapse repeated whitespace.                |
+| `Employment Status`          | `normalize(...)`; used to flip `isDeactivated` when the status is anything other than `active`. |
+| `Position`                   | `normalize(...)`; also drives tag assignment via `data/position_mapping.csv`.                   |
+| `Work_Location`              | `normalize(...)`; used for both tags and the time zone lookup in `data/location_mapping.csv`.    |
+| `Work Email`                 | `value.strip().lower()`; empty strings collapse to `""`.                                        |
+| `Mobile Phone`, `Work Phone` | Digits-only (``"".join(ch for ch in value if ch.isdigit())``) to remove formatting characters. |
+| `Driver License Number`      | `normalize(...)`                                                                                 |
+| `Driver License State`       | `normalize(...)`                                                                                 |
+| `Supervisor Employee Code`   | `sanitize_external_id_value(...)`                                                               |
+
+Blank or missing values contribute empty strings so the field order remains
+stable. Because the hash is deterministic, any change to the normalized values
+above regenerates `paycom_fingerprint` and forces a PATCH the next time the
+sync runs.
+
+#### Patch triggers
+
+During reconciliation the sync evaluates the current Samsara driver alongside
+the freshly computed payload and issues a `PATCH /fleet/drivers/{id}` when any
+of the following are true:
+
+- `externalIds.employeeCode` is missing or differs from the sanitized Paycom
+  value.
+- `externalIds.paycom_fingerprint` is missing or does not match the newly
+  computed fingerprint.
+- Location or position derived tags/time zone disagree with the current driver
+  record (for example, a driver transferring depots or changing job family).
+- The `Employment Status` flip requires toggling `isDeactivated`.
+
+If none of those checks fail, the record is skipped and no API write is issued.
+
+#### Example fingerprint + payload
+
+```python
+from hashlib import sha256
+
+from encompass_to_samsara.transform import normalize, sanitize_external_id_value
+
+
+def normalize_phone(value: str | None) -> str:
+    return "".join(ch for ch in (value or "") if ch.isdigit())
+
+
+def compute_paycom_fingerprint(row: dict[str, str]) -> str:
+    parts = [
+        normalize(row.get("First Name")),
+        normalize(row.get("Preferred Name")),
+        normalize(row.get("Last Name")),
+        normalize(row.get("Employment Status")),
+        normalize(row.get("Position")),
+        normalize(row.get("Work_Location")),
+        (row.get("Work Email") or "").strip().lower(),
+        normalize_phone(row.get("Mobile Phone")),
+        normalize_phone(row.get("Work Phone")),
+        normalize(row.get("Driver License Number")),
+        normalize(row.get("Driver License State")),
+        sanitize_external_id_value(row.get("Supervisor Employee Code")) or "",
+    ]
+    return sha256("|".join(parts).encode("utf-8")).hexdigest()
+
+
+location_index = {
+    "Austin": {"tag_id": "2762148", "tz": "America/Chicago"},
+    # ... additional rows loaded from data/location_mapping.csv
+}
+position_tags = {
+    "Delivery Driver": "4134370",
+    # ... additional mappings from data/position_mapping.csv
+}
+
+
+def build_driver_payload(row: dict[str, str]) -> dict[str, object]:
+    loc_info = location_index.get(row.get("Work_Location"))
+    tag_ids = []
+    if loc_info and loc_info.get("tag_id"):
+        tag_ids.append(loc_info["tag_id"])
+    if tag := position_tags.get(row.get("Position")):
+        tag_ids.append(tag)
+    payload = {
+        "firstName": row.get("First Name") or "",
+        "lastName": row.get("Last Name") or "",
+        "email": (row.get("Work Email") or "").strip().lower() or None,
+        "phone": normalize_phone(row.get("Mobile Phone")) or None,
+        "timeZone": (loc_info or {}).get("tz", "America/Chicago"),
+        "tagIds": tag_ids,
+        "isDeactivated": normalize(row.get("Employment Status")) != "active",
+        "externalIds": {
+            "employeeCode": sanitize_external_id_value(row.get("Employee Code")) or None,
+            "paycom_fingerprint": compute_paycom_fingerprint(row),
+        },
+    }
+    return payload
+```
+
 ### Safety rails
 
 - Only touch addresses with `externalIds.encompassid` or tag `ManagedBy:EncompassSync`.


### PR DESCRIPTION
## Summary
- document the Paycom-specific `employeeCode` and `paycom_fingerprint` external identifiers in the README, including how they are sanitized and used
- describe the normalized field set, patch triggers, and provide an example snippet for computing the fingerprint and building a driver payload

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'encompass_to_samsara')*


------
https://chatgpt.com/codex/tasks/task_e_68c87fb5c6dc8328ab128d69ad894ad7